### PR TITLE
ignore ticks with GOTR deposit pool interactions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 }
 
 group = 'com.profittracker'
-version = '1.2'
+version = '1.3'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -249,8 +249,8 @@ public class ProfitTrackerPlugin extends Plugin
         log.debug(String.format("Click! ID: %d ,menuOption: %s, menuTarget: %s",
                   event.getId(), event.getMenuOption(), event.getMenuTarget()));
 
-        if (event.getId() == ObjectID.BANK_DEPOSIT_BOX) {
-            // we've interacted with a deposit box. Don't take this tick into account for profit calculation
+        if (event.getId() == ObjectID.BANK_DEPOSIT_BOX || event.getId() == ObjectID.DEPOSIT_POOL) {
+            // we've interacted with a deposit box/pool. Don't take this tick into account for profit calculation
             skipTickForProfitCalculation = true;
         }
 


### PR DESCRIPTION
Just a little annoying thing I noticed with this plugin in GOTR - depositing runes in the deposit pool counts as losing value, but should be treated the same as a bank deposit box.