### PR TITLE
Greatly improved price tracking consistency, fixed edge cases, and other QoL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- <img src="https://oldschool.runescape.wiki/images/thumb/3/36/Coins_10000_detail.png/1024px-Coins_10000_detail.png?e07e3" width="200" title="hover text">
+ <img src="https://oldschool.runescape.wiki/images/Coins_detail.png?404bc" width="200" title="Coins 10000+">
  
  
 # Profit Tracker Plugin
@@ -13,24 +13,25 @@ Depositing or withdrawing items will not affect profit value.
 
 
 # Gold drops
-Every change in your inventory is monitored and a corresponding profit animation will be shown.
+Every change in your inventory and bank is monitored and a corresponding profit animation will be shown.
 ![image](https://user-images.githubusercontent.com/8212109/94357070-393c0680-009e-11eb-96a1-8fa7469ee6e1.png)
 
 For example, if you buy in a general shop, an item for 20 coins, which is worth in GE 220 coins,
 ProfitTracker will generate a gold drop animation of 200 coins.
 
 # How to use
-The plugin will simply begin tracking when it is loaded. So be sure to reload the plugin when you are starting your money routine!
+The plugin will begin tracking when entering the game. Be sure to reload the plugin when you are starting a new money routine!
+
+Certain actions will not be recorded as profit unless the bank has been opened at least once to create a baseline, and again to see changes. Things like using a deposit box to empty storage pouches, or banking items directly from reward chests. So make sure to open up the bank once for better accuracy before doing those things.
 
 # Running the plugin from repo
 Clone the repo, and run ProfitTrackerTest java class from Intellij.
 
 # Missing features
-I've developed this while being F2P. 
+I've developed this while being F2P.
 There is no tracking of member stuff like tridents, dwarf cannon.
 
 # Credits
 Credit to wikiworm (Brandon Ripley) for his runelite plugin
 https://github.com/wikiworm/InventoryValue
 which helped for the creation of this plugin!
-

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 }
 
 group = 'com.profittracker'
-version = '1.4'
+version = '1.5'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/profittracker/ProfitTrackerConfig.java
+++ b/src/main/java/com/profittracker/ProfitTrackerConfig.java
@@ -20,5 +20,15 @@ public interface ProfitTrackerConfig extends Config
     {
         return true;
     }
+
+    @ConfigItem(
+            keyName = "autoStart",
+            name = "Automatically start tracking",
+            description = "Automatically begin tracking profit on session start."
+    )
+    default boolean autoStart()
+    {
+        return true;
+    }
 }
 

--- a/src/main/java/com/profittracker/ProfitTrackerGoldDrops.java
+++ b/src/main/java/com/profittracker/ProfitTrackerGoldDrops.java
@@ -242,22 +242,56 @@ public class ProfitTrackerGoldDrops {
 
     private String formatGoldDropText(long goldDropValue)
     {
-        // format gold value runescape style
-        // up to 10,000K
-        // I.E: 100,000 -> 100K
+        // Format gold value to fit in xp drop to avoid being cutoff by gold sprite
+        // 999
+        // 1.0K
+        // 20K
+        // 300K
+        // 1.0M
 
-        if (Math.abs(goldDropValue) < 10000L)
-        {
+        float goldValueRep = goldDropValue;
+        String suffix = "";
+        boolean useDecimal = false;
+        if (Math.abs(goldDropValue) < 1000L) { // 1-999
             return Long.toString(goldDropValue);
         }
-        else if (Math.abs(goldDropValue) < 1000L * 1000L)
+        else if (Math.abs(goldDropValue) < 10000L) // 1,000-9,999
         {
-            return (goldDropValue / 1000) + "K";
+            goldValueRep = (goldDropValue / 1000.0F);
+            suffix = "K";
+            useDecimal = true;
+        }
+        else if (Math.abs(goldDropValue) < 1000000L) // 10,000-999,999
+        {
+            goldValueRep = (goldDropValue / 1000.0F);
+            suffix = "K";
+        }
+        else if (Math.abs(goldDropValue) < 10000000L) // 1,000,000-9,999,999
+        {
+            goldValueRep = (goldDropValue / 1000000.0F);
+            suffix = "M";
+            useDecimal = true;
+        }
+        else if (Math.abs(goldDropValue) < 1000000000L) // 10,000,000-999,999,999
+        {
+            goldValueRep = (goldDropValue / 1000000.0F);
+            suffix = "M";
+        }
+        else if (Math.abs(goldDropValue) < 1000000000000L) // 1,000,000,000+
+        {
+            goldValueRep = (goldDropValue / 1000000000.0F);
+            suffix = "B";
+            useDecimal = true;
         }
         else
         {
             return "ALOT";
         }
-
+        if(useDecimal)
+        {
+            return String.format("%.1f%s", goldValueRep, suffix);
+        }else{
+            return String.format("%.0f%s", goldValueRep, suffix);
+        }
     }
 }

--- a/src/main/java/com/profittracker/ProfitTrackerGoldDrops.java
+++ b/src/main/java/com/profittracker/ProfitTrackerGoldDrops.java
@@ -289,9 +289,9 @@ public class ProfitTrackerGoldDrops {
         }
         if(useDecimal)
         {
-            return String.format("%.1f%s", goldValueRep, suffix);
+            return String.format("%.1f%s", Math.floor(goldValueRep * 10) / 10, suffix);
         }else{
-            return String.format("%.0f%s", goldValueRep, suffix);
+            return String.format("%.0f%s", Math.floor(goldValueRep * 10) / 10, suffix);
         }
     }
 }

--- a/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
+++ b/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
@@ -228,37 +228,37 @@ public class ProfitTrackerInventoryValue {
      * @param newItems
      * @return
      */
-    public Item[] getItemCollectionDif(Item[] originalItems, Item[] newItems){
+    public Item[] getItemCollectionDifference(Item[] originalItems, Item[] newItems){
         //Iterate over each item, finding any instances of its existence from before
         Item[] negativeItems = originalItems.clone();
         for (int i = 0; i < originalItems.length; i++){
             negativeItems[i] = new Item(originalItems[i].getId(),-originalItems[i].getQuantity());
         }
-        Item[] itemIntermediateDif = ArrayUtils.addAll(negativeItems,newItems);
+        Item[] itemIntermediateDifference = ArrayUtils.addAll(negativeItems,newItems);
 
         //Create a nicer looking item list with only the actual changes
-        HashMap<Integer, Integer> itemDifHash = new HashMap<>();
+        HashMap<Integer, Integer> itemDifferenceHash = new HashMap<>();
 
-        for (int i = 0; i < itemIntermediateDif.length; i++){
-            int itemID = itemIntermediateDif[i].getId();
-            itemDifHash.putIfAbsent(itemID, 0);
-            itemDifHash.put(itemID, itemDifHash.get(itemID) + itemIntermediateDif[i].getQuantity());
+        for (int i = 0; i < itemIntermediateDifference.length; i++){
+            int itemID = itemIntermediateDifference[i].getId();
+            itemDifferenceHash.putIfAbsent(itemID, 0);
+            itemDifferenceHash.put(itemID, itemDifferenceHash.get(itemID) + itemIntermediateDifference[i].getQuantity());
         }
 
-        Iterator mapIt = itemDifHash.entrySet().iterator();
+        Iterator mapIt = itemDifferenceHash.entrySet().iterator();
         while (mapIt.hasNext()){
             Map.Entry pair = (Map.Entry)mapIt.next();
             if ((Integer)(pair.getValue()) == 0){
                 mapIt.remove();
             }
         }
-        List<Item> itemDif = new ArrayList<>();
-        mapIt = itemDifHash.entrySet().iterator();
+        List<Item> itemDifference = new ArrayList<>();
+        mapIt = itemDifferenceHash.entrySet().iterator();
         while (mapIt.hasNext()){
             Map.Entry pair = (Map.Entry)mapIt.next();
-            itemDif.add(new Item((Integer)pair.getKey(),(Integer)pair.getValue()));
+            itemDifference.add(new Item((Integer)pair.getKey(),(Integer)pair.getValue()));
         }
 
-        return itemDif.toArray(new Item[0]);
+        return itemDifference.toArray(new Item[0]);
     }
 }

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -289,20 +289,63 @@ public class ProfitTrackerPlugin extends Plugin
             skipTickForProfitCalculation = true;
         }
 
+        // Ignore losses incurred by filling container items that are only empty-able to the bank
         switch (event.getItemId()) {
-            case ItemID.PLANK_SACK:
+            case ItemID.PLANK_SACK: // Fill, empty | use (dumps into inventory)
+                // Items can be used directly from sack
+                // Filling sack requires inventory as intermediate
             case ItemID.FISH_SACK_BARREL:
-            case ItemID.FISH_BARREL:
-            case ItemID.COAL_BAG:
-            case ItemID.COLOSSAL_POUCH:
+            case ItemID.FISH_BARREL: //Fill, open | empty
+
+            case ItemID.BRONZE_COFFIN: // Fill, configure, open
+            case ItemID.BLACK_COFFIN:
+            case ItemID.STEEL_COFFIN:
+            case ItemID.SILVER_COFFIN:
+            case ItemID.GOLD_COFFIN:
+
+            case ItemID.GEM_BAG: //Fill, empty, open | empty
+            case ItemID.COAL_BAG: // Fill, empty, open | fill, empty
+                //Coal can be directly used from the sack, and be filled directly from bank
+
+            case ItemID.COLOSSAL_POUCH: // Fill, empty | fill, empty
+            case ItemID.GIANT_POUCH:
             case ItemID.LARGE_POUCH:
             case ItemID.MEDIUM_POUCH:
             case ItemID.SMALL_POUCH:
-            case ItemID.FORESTRY_KIT:
-            case ItemID.FORESTRY_BASKET:
-                if (menuOption.equalsIgnoreCase("empty") || menuOption.equalsIgnoreCase("fill")){
-                    // Ignore manual changes to container items as the items have not been lost
-                    skipTickForProfitCalculation = true;
+
+            // case ItemID.BASKET: //Fill, remove-one, empty | fill | basket turns into different name like "Bananas(#)"
+                //Empty sack
+            case ItemID.BOLT_POUCH: //Open(remove interface) | | bolts can be worn via armor interface extra ammo slot
+            case ItemID.HERB_SACK: // Fill, empty, open | empty
+                //Looting bag
+                //Rune pouch // Covered by withdraw interface
+            case ItemID.SEED_BOX: // Open
+            case ItemID.STEEL_KEY_RING: //Add keys via use on ring | remove via remove interface
+                //Flamtaer bag // Fill, empty | empty (dumps into inventory) | items can be used directly from sack
+                //Tackle box
+            case ItemID.MASTER_SCROLL_BOOK: // Interface with remove option | items can be used from book via activate and teleport
+                //Gnomish firelighter // Check, uncharge
+
+            case ItemID.LOG_BASKET: // Fill, Check(dialog based withdraw), Close/Open | Empty
+            case ItemID.FORESTRY_KIT: // View(kit has withdraw interface), Fill | Use(dumps to bank)
+            case ItemID.FORESTRY_BASKET: // Fill, view(kit has withdraw interface/basket has none) | use (dumps to bank)
+
+            case ItemID.SMALL_MEAT_POUCH: // Fill, Empty
+            case ItemID.LARGE_MEAT_POUCH: // Fill, Empty
+            case ItemID.SMALL_FUR_POUCH: // Fill, Empty
+            case ItemID.MEDIUM_FUR_POUCH: // Fill, Empty
+            case ItemID.LARGE_FUR_POUCH: // Fill, Empty
+
+            case ItemID.REAGENT_POUCH: // ??? | Use (dumps to bank)
+                switch (menuOption.toLowerCase()) {
+                    case "empty":
+                    case "fill":
+                    case "use":
+                        log.debug("Ignoring storage item interaction.");
+                        // Ignore manual changes to container items as the items have not been lost
+                        skipTickForProfitCalculation = true;
+                }
+                break;
                 }
         }
     }

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -346,7 +346,39 @@ public class ProfitTrackerPlugin extends Plugin
                         skipTickForProfitCalculation = true;
                 }
                 break;
+            // Don't ignore open containers, as items added directly to them don't get recorded
+            case ItemID.OPEN_FISH_SACK_BARREL:
+            case ItemID.OPEN_FISH_BARREL:
+            case ItemID.OPEN_BRONZE_COFFIN: // Fill, configure, open
+            case ItemID.OPEN_BLACK_COFFIN:
+            case ItemID.OPEN_STEEL_COFFIN:
+            case ItemID.OPEN_SILVER_COFFIN:
+            case ItemID.OPEN_GOLD_COFFIN:
+
+            case ItemID.OPEN_GEM_BAG:
+            case ItemID.OPEN_COAL_BAG:
+
+            case ItemID.OPEN_HERB_SACK:
+            case ItemID.OPEN_LOG_BASKET:
+            case ItemID.OPEN_FORESTRY_BASKET:
+
+            case ItemID.SMALL_MEAT_POUCH_OPEN: // Fill, Empty
+            case ItemID.LARGE_MEAT_POUCH_OPEN: // Fill, Empty
+            case ItemID.SMALL_FUR_POUCH_OPEN: // Fill, Empty
+            case ItemID.MEDIUM_FUR_POUCH_OPEN: // Fill, Empty
+            case ItemID.LARGE_FUR_POUCH_OPEN: // Fill, Empty
+
+            case ItemID.OPEN_REAGENT_POUCH:
+                switch (menuOption.toLowerCase()) {
+                    // Empty is not ignored, as we want an option to calculate profit for unrecorded items that
+                    // were sucked into the container directly
+                    case "fill":
+                    case "use":
+                        log.debug("Ignoring open storage item interaction.");
+                        // Ignore manual changes to container items as the items have not been lost
+                        skipTickForProfitCalculation = true;
                 }
+                break;
         }
     }
 

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -248,9 +248,16 @@ public class ProfitTrackerPlugin extends Plugin
         /* for ignoring deposit in deposit box */
         log.debug(String.format("Click! ID: %d ,menuOption: %s, menuTarget: %s",
                   event.getId(), event.getMenuOption(), event.getMenuTarget()));
+        String menuOption = event.getMenuOption();
+        switch (event.getId()){
+            case ObjectID.BANK_DEPOSIT_BOX:
+            case ObjectID.DEPOSIT_POOL:
+                // we've interacted with a deposit box/pool. Don't take this tick into account for profit calculation
+                skipTickForProfitCalculation = true;
+        }
 
-        if (event.getId() == ObjectID.BANK_DEPOSIT_BOX || event.getId() == ObjectID.DEPOSIT_POOL) {
-            // we've interacted with a deposit box/pool. Don't take this tick into account for profit calculation
+        if (event.getId() == 1 && (menuOption.startsWith("Withdraw-") || menuOption.startsWith("Deposit-"))){
+            // Interacting with bank, because itemContainerChanged does not report bank change if closed on same tick
             skipTickForProfitCalculation = true;
         }
 

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -15,6 +15,7 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.api.events.VarbitChanged;
+import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.Arrays;
 
@@ -96,8 +97,8 @@ public class ProfitTrackerPlugin extends Plugin
 
     private void initializeVariables()
     {
-        // value here doesn't matter, will be overwritten
-        prevInventoryValue = -1;
+        prevInventoryItems = null;
+        prevBankItems = null;
 
         // profit begins at 0 of course
         totalProfit = 0;
@@ -242,8 +243,8 @@ public class ProfitTrackerPlugin extends Plugin
         Item[] newInventoryItems;
         Item[] newBankItems;
         long newProfit;
-        Item[] inventoryDif;
-        Item[] bankDif = new Item[0];
+        Item[] inventoryDifference;
+        Item[] bankDifference = new Item[0];
 
         // calculate current inventory value
         //newInventoryValue = inventoryValueObject.calculateInventoryAndEquipmentValue();
@@ -254,13 +255,16 @@ public class ProfitTrackerPlugin extends Plugin
         {
             // calculate new profit
             // newProfit = newInventoryValue - prevInventoryValue;
-            inventoryDif = inventoryValueObject.getItemCollectionDifference(prevInventoryItems,newInventoryItems);
-            newProfit = inventoryValueObject.calculateItemValue(inventoryDif);
+            inventoryDifference = inventoryValueObject.getItemCollectionDifference(prevInventoryItems,newInventoryItems);
+            newProfit = inventoryValueObject.calculateItemValue(inventoryDifference);
             if (prevBankItems != null && newBankItems != null) {
-                bankDif = inventoryValueObject.getItemCollectionDifference(prevBankItems,newBankItems);
-                newProfit += inventoryValueObject.calculateItemValue(bankDif);
+                bankDifference = inventoryValueObject.getItemCollectionDifference(prevBankItems,newBankItems);
+                // Profit is recalculated on all items instead of summed just in case item values could change between calculations
+                Item[] inventoryAndBankDifference = ArrayUtils.addAll(inventoryDifference,bankDifference);
+                newProfit = inventoryValueObject.calculateItemValue(inventoryAndBankDifference);
             }
-            log.debug("Calculated profit for " + inventoryDif.length + bankDif.length + " item changes.");
+
+            log.debug("Calculated " + newProfit + " profit for " + (inventoryDifference.length + bankDifference.length) + " item changes.");
         }
         else
         {

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -265,6 +265,9 @@ public class ProfitTrackerPlugin extends Plugin
     public void onVarbitChanged(VarbitChanged event)
     {
         runePouchContentsChanged = Arrays.stream(RUNE_POUCH_VARBITS).anyMatch(vb -> event.getVarbitId() == vb);
+        if (Arrays.stream(RUNE_POUCH_VARBITS).anyMatch(vb -> event.getVarbitId() == vb)){
+            runePouchContentsChanged = true;
+        }
     }
 
     @Subscribe

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -222,10 +222,6 @@ public class ProfitTrackerPlugin extends Plugin
     @Subscribe
     public void onWidgetClosed(WidgetClosed event)
     {
-        //Catch bank closing, as tick perfect close can cause onItemContainerChanged to not think it is in the bank
-        if (event.getGroupId() == WidgetID.BANK_GROUP_ID ||
-            event.getGroupId() == WidgetID.BANK_INVENTORY_GROUP_ID ||
-            event.getGroupId() == 871) { //Huntsman's kit
         //Catch untracked storage closing, as tick perfect close can cause onItemContainerChanged to not see the change
         if (event.getGroupId() == 871 || //Huntsman's kit
             event.getGroupId() == WidgetID.SEED_VAULT_GROUP_ID) { // Seed vault

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -226,6 +226,9 @@ public class ProfitTrackerPlugin extends Plugin
         if (event.getGroupId() == WidgetID.BANK_GROUP_ID ||
             event.getGroupId() == WidgetID.BANK_INVENTORY_GROUP_ID ||
             event.getGroupId() == 871) { //Huntsman's kit
+        //Catch untracked storage closing, as tick perfect close can cause onItemContainerChanged to not see the change
+        if (event.getGroupId() == 871 || //Huntsman's kit
+            event.getGroupId() == WidgetID.SEED_VAULT_GROUP_ID) { // Seed vault
             bankJustClosed = true;
         }
     }

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -273,20 +273,15 @@ public class ProfitTrackerPlugin extends Plugin
         log.debug(String.format("Click! ID: %d ,menuOption: %s, menuTarget: %s",
                   event.getId(), event.getMenuOption(), event.getMenuTarget()));
         String menuOption = event.getMenuOption();
-        switch (event.getId()){
-            case ObjectID.BANK_DEPOSIT_BOX:
-            case ObjectID.DEPOSIT_POOL:
-                // we've interacted with a deposit box/pool. Don't take this tick into account for profit calculation
-                skipTickForProfitCalculation = true;
-        }
 
-        if (event.getId() == 1 && (menuOption.startsWith("Withdraw-") || menuOption.startsWith("Deposit-"))){
-            // Interacting with bank, because itemContainerChanged does not report bank change if closed on same tick
-            skipTickForProfitCalculation = true;
-        }
-        if (event.getId() == ObjectID.BANK_DEPOSIT_BOX || event.getId() == ObjectID.DEPOSIT_POOL || event.getId() == ObjectID.BANK_DEPOSIT_CHEST) {
-            // we've interacted with a deposit box/pool. Don't take this tick into account for profit calculation
-            skipTickForProfitCalculation = true;
+        String containerMenuOptions[] = {"Deposit","Empty"};
+        for (int i = 0; i < containerMenuOptions.length; i++){
+            if (menuOption.startsWith(containerMenuOptions[i])){
+                // Backup catch for various bank interfaces to deposit or empty sacks
+                // Event object does not seem to provide information that would otherwise tell us it's a bank
+                skipTickForProfitCalculation = true;
+                break;
+            }
         }
 
         // Ignore losses incurred by filling container items that are only empty-able to the bank

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -261,7 +261,22 @@ public class ProfitTrackerPlugin extends Plugin
             skipTickForProfitCalculation = true;
         }
 
-
+        switch (event.getItemId()) {
+            case ItemID.PLANK_SACK:
+            case ItemID.FISH_SACK_BARREL:
+            case ItemID.FISH_BARREL:
+            case ItemID.COAL_BAG:
+            case ItemID.COLOSSAL_POUCH:
+            case ItemID.LARGE_POUCH:
+            case ItemID.MEDIUM_POUCH:
+            case ItemID.SMALL_POUCH:
+            case ItemID.FORESTRY_KIT:
+            case ItemID.FORESTRY_BASKET:
+                if (menuOption.equalsIgnoreCase("empty") || menuOption.equalsIgnoreCase("fill")){
+                    // Ignore manual changes to container items as the items have not been lost
+                    skipTickForProfitCalculation = true;
+                }
+        }
     }
 
     @Provides


### PR DESCRIPTION
## Fixes
* Fixed negative gold values being partially hidden by the gold icon by altering the number formatting
* Fixed depositing or withdrawing items from the bank the same tick it is closed causing profit to change (re-opening bank after it happens will reconcile the change)
* Added additional monitoring to ensure deposit box profit is accounted for (resolves #13)
* Fixed rune pouch changes often not updating profit until something else happens (resolves #10)
* Minute by minute GE price changes of held and worn items will no longer interfere with profit
* Huntsmans kit interaction no longer interferes with profit
* Seed vault no longer interferes with profit (resolves #16)
* Fixed opening bank interfaces and doing nothing causing the next change to be ignored
* Fixed readme pointing to broken image

## Improvements
* Included bank as a resource to monitor profit (emptying pouches, banking reward chests)
* Added automatic start setting to begin tracking on first game tick