### PR TITLE
Grand exchange tracking, untradeables profit, fixes, improvements, and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ NOTE: I've stopped working on this, I will probably not fix much of the issues. 
 This runelite plugin tracks the profit you are generating, according to GE, while money-making.
 ![image](https://user-images.githubusercontent.com/8212109/94357201-5d4c1780-009f-11eb-9c73-17c279edd613.png)
 
-For example, if you are filling vials, the plugin will accumlate profit each time you fill vial, accounting for empty vials price in GE.
+For example, if you are filling vials, the plugin will accumulate profit each time you fill vial, accounting for empty vials price in GE.
 Depositing or withdrawing items will not affect profit value.
 
 
@@ -20,11 +20,11 @@ For example, if you buy in a general shop, an item for 20 coins, which is worth 
 ProfitTracker will generate a gold drop animation of 200 coins.
 
 # How to use
-The plugin will begin tracking when entering the game. Be sure to reload the plugin when you are starting a new money routine!
+The plugin will begin tracking when entering the game. The session can be reset by using shift + right click on the overlay, or by reloading the plugin.
 
 Certain actions will not be recorded as profit unless the bank has been opened at least once to create a baseline, and again to see changes. Things like using a deposit box to empty storage pouches, or banking items directly from reward chests. So make sure to open up the bank once for better accuracy before doing those things.
 
-If using the GE, open the bank first so gold withdrawn automatically for trades is not counted as profit.
+If using the GE, open the bank first so gold withdrawn automatically for trades can be detected and recovered upon opening the bank again.
 
 Grand exchange profits are calculated when the exchange or collection box is open.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For example, if you buy in a general shop, an item for 20 coins, which is worth 
 ProfitTracker will generate a gold drop animation of 200 coins.
 
 # How to use
-The plugin will begin tracking when entering the game. The session can be reset by using shift + right click on the overlay, or by reloading the plugin.
+The plugin will begin tracking when entering the game. The session can be reset by using shift + right-click on the overlay, or by reloading the plugin.
 
 Certain actions will not be recorded as profit unless the bank has been opened at least once to create a baseline, and again to see changes. Things like using a deposit box to empty storage pouches, or banking items directly from reward chests. So make sure to open up the bank once for better accuracy before doing those things.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Depositing or withdrawing items will not affect profit value.
 
 
 # Gold drops
-Every change in your inventory and bank is monitored and a corresponding profit animation will be shown.
+Every change in your inventory, bank, and grand exchange box is monitored and a corresponding profit animation will be shown.
 ![image](https://user-images.githubusercontent.com/8212109/94357070-393c0680-009e-11eb-96a1-8fa7469ee6e1.png)
 
 For example, if you buy in a general shop, an item for 20 coins, which is worth in GE 220 coins,
@@ -24,12 +24,17 @@ The plugin will begin tracking when entering the game. Be sure to reload the plu
 
 Certain actions will not be recorded as profit unless the bank has been opened at least once to create a baseline, and again to see changes. Things like using a deposit box to empty storage pouches, or banking items directly from reward chests. So make sure to open up the bank once for better accuracy before doing those things.
 
+If using the GE, open the bank first so gold withdrawn automatically for trades is not counted as profit.
+
+Grand exchange profits are calculated when the exchange or collection box is open.
+
 # Running the plugin from repo
 Clone the repo, and run ProfitTrackerTest java class from Intellij.
 
 # Missing features
-I've developed this while being F2P.
-There is no tracking of member stuff like tridents, dwarf cannon.
+Items that store other items for charges like powered staves or elemental tomes only cause profit when charging or unchanging, not through regular use. Start and end a session with the item uncharged for the most accuracy.
+
+Some permanent storage locations may not be tracked, causing items stored or withdrawn to record profit or loss. Things like deaths storage, PoH costume room, stashes, or raid storage.
 
 # Credits
 Credit to wikiworm (Brandon Ripley) for his runelite plugin

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 }
 
 group = 'com.profittracker'
-version = '1.5'
+version = '1.6'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/profittracker/ProfitTrackerConfig.java
+++ b/src/main/java/com/profittracker/ProfitTrackerConfig.java
@@ -82,5 +82,16 @@ public interface ProfitTrackerConfig extends Config
     {
         return true;
     }
+
+    @ConfigItem(
+            keyName = "onlineOnlyRate",
+            name = "Online only rate",
+            description = "Show profit rate only for time spent logged in. Timer pacing will be uneven due to updating every tick.",
+            section = visualSettings
+    )
+    default boolean onlineOnlyRate()
+    {
+        return false;
+    }
 }
 

--- a/src/main/java/com/profittracker/ProfitTrackerConfig.java
+++ b/src/main/java/com/profittracker/ProfitTrackerConfig.java
@@ -86,7 +86,7 @@ public interface ProfitTrackerConfig extends Config
     @ConfigItem(
             keyName = "onlineOnlyRate",
             name = "Online only rate",
-            description = "Show profit rate only for time spent logged in. Timer pacing will be uneven due to updating every tick.",
+            description = "Show profit rate only for time spent logged in.",
             section = visualSettings
     )
     default boolean onlineOnlyRate()

--- a/src/main/java/com/profittracker/ProfitTrackerConfig.java
+++ b/src/main/java/com/profittracker/ProfitTrackerConfig.java
@@ -30,5 +30,25 @@ public interface ProfitTrackerConfig extends Config
     {
         return true;
     }
+
+    @ConfigItem(
+            keyName = "shortDrops",
+            name = "Shorten drop numbers",
+            description = "Shorten drop numbers like 1.2K instead of 1,223, or 10M instead of 10,000,000"
+    )
+    default boolean shortDrops()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "iconStyle",
+            name = "Icon style",
+            description = "Dynamically adjust the coin icon based on the drop value, or select a specific icon."
+    )
+    default ProfitTrackerIconType iconStyle()
+    {
+        return ProfitTrackerIconType.DYNAMIC;
+    }
 }
 

--- a/src/main/java/com/profittracker/ProfitTrackerConfig.java
+++ b/src/main/java/com/profittracker/ProfitTrackerConfig.java
@@ -3,6 +3,7 @@ package com.profittracker;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 /**
  * The ProfitTrackerConfig class is used to provide user preferences to the ProfitTrackerPlugin.
@@ -11,10 +12,27 @@ import net.runelite.client.config.ConfigItem;
 public interface ProfitTrackerConfig extends Config
 {
 
+    @ConfigSection(
+            name = "Visual",
+            description = "Settings for what the plugin features look like.",
+            position =  0,
+            closedByDefault = false
+    )
+    String visualSettings = "Visual";
+
+    @ConfigSection(
+            name = "Behavior",
+            description = "Settings for calculation behavior.",
+            position =  1,
+            closedByDefault = false
+    )
+    String behaviorSettings = "Behavior";
+
     @ConfigItem(
             keyName = "goldDrops",
-            name = "Show value changes (gold drops) ",
-            description = "Show each profit increase or decrease"
+            name = "Show value changes (gold drops)",
+            description = "Show each profit increase or decrease.",
+            section = visualSettings
     )
     default boolean goldDrops()
     {
@@ -24,7 +42,8 @@ public interface ProfitTrackerConfig extends Config
     @ConfigItem(
             keyName = "autoStart",
             name = "Automatically start tracking",
-            description = "Automatically begin tracking profit on session start."
+            description = "Automatically begin tracking profit on session start.",
+            section = behaviorSettings
     )
     default boolean autoStart()
     {
@@ -34,7 +53,8 @@ public interface ProfitTrackerConfig extends Config
     @ConfigItem(
             keyName = "shortDrops",
             name = "Shorten drop numbers",
-            description = "Shorten drop numbers like 1.2K instead of 1,223, or 10M instead of 10,000,000"
+            description = "Shorten drop numbers like 1.2K instead of 1,223, or 10M instead of 10,000,000.",
+            section = visualSettings
     )
     default boolean shortDrops()
     {
@@ -44,7 +64,8 @@ public interface ProfitTrackerConfig extends Config
     @ConfigItem(
             keyName = "iconStyle",
             name = "Icon style",
-            description = "Dynamically adjust the coin icon based on the drop value, or select a specific icon."
+            description = "Dynamically adjust the coin icon based on the drop value, or select a specific icon.",
+            section = visualSettings
     )
     default ProfitTrackerIconType iconStyle()
     {
@@ -54,7 +75,8 @@ public interface ProfitTrackerConfig extends Config
     @ConfigItem(
             keyName = "estimateUntradeables",
             name = "Estimate untradeable item values",
-            description = "Some untradeable items will utilize equivalent values of the best items they can convert into."
+            description = "Some untradeable items will utilize equivalent values of the best items they can convert into.",
+            section = behaviorSettings
     )
     default boolean estimateUntradeables()
     {

--- a/src/main/java/com/profittracker/ProfitTrackerConfig.java
+++ b/src/main/java/com/profittracker/ProfitTrackerConfig.java
@@ -50,5 +50,15 @@ public interface ProfitTrackerConfig extends Config
     {
         return ProfitTrackerIconType.DYNAMIC;
     }
+
+    @ConfigItem(
+            keyName = "estimateUntradeables",
+            name = "Estimate untradeable item values",
+            description = "Some untradeable items will utilize equivalent values of the best items they can convert into."
+    )
+    default boolean estimateUntradeables()
+    {
+        return true;
+    }
 }
 

--- a/src/main/java/com/profittracker/ProfitTrackerGoldDrops.java
+++ b/src/main/java/com/profittracker/ProfitTrackerGoldDrops.java
@@ -3,7 +3,9 @@ package com.profittracker;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.events.ScriptPreFired;
-import net.runelite.api.widgets.InterfaceID;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.api.gameval.ItemID;
+import net.runelite.api.gameval.VarbitID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.util.AsyncBufferedImage;
@@ -22,7 +24,7 @@ public class ProfitTrackerGoldDrops {
        which is intended to generate xp drops for maxed out skills.
        Fake XP Drops are composed of a skill sprite,
         and a text widget with a mod icon (<img=11> in text)
-       So to create a gold drop, we create a fake xp drop, and interefere in the middle,
+       So to create a gold drop, we create a fake xp drop, and interfere in the middle,
        and change the sprite and text to our liking.
 
        Flow is:
@@ -32,7 +34,7 @@ public class ProfitTrackerGoldDrops {
 
        A more correct way to do this is probably by calling Item.GetImage with wanted
        coin quantity, which will give us correct coin icon and correct text,
-       and simply drawing that image ourselfs somehow. Instead of using xp drop mechanism.
+       and simply drawing that image ourselves somehow. Instead of using xp drop mechanism.
      */
 
     /*
@@ -115,7 +117,7 @@ public class ProfitTrackerGoldDrops {
         Widget[] xpDropWidgetChildren;
 
         // get widget from ID
-        xpDropWidget = client.getWidget(InterfaceID.EXPERIENCE_TRACKER, xpDropWidgetId & 0xFFFF);
+        xpDropWidget = client.getWidget(InterfaceID.XP_DROPS, xpDropWidgetId & 0xFFFF);
 
         if (xpDropWidget == null)
         {
@@ -194,7 +196,7 @@ public class ProfitTrackerGoldDrops {
         AsyncBufferedImage coin_image_raw;
 
         // get image object by coin item id
-        coin_image_raw = itemManager.getImage(ItemID.COINS_995, 10000, false);
+        coin_image_raw = itemManager.getImage(ItemID.COINS, 10000, false);
 
         // since getImage returns an AsyncBufferedImage, which is not loaded initially,
         // we schedule sprite conversion and sprite override for when the image is actually loaded
@@ -234,14 +236,14 @@ public class ProfitTrackerGoldDrops {
     {
         // taken from XpDropPlugin
         EnumComposition colorEnum = client.getEnum(EnumID.XPDROP_COLORS);
-        int defaultColorId = client.getVarbitValue(Varbits.EXPERIENCE_DROP_COLOR);
+        int defaultColorId = client.getVarbitValue(VarbitID.XPDROPS_COLOUR);
         int color = colorEnum.getIntValue(defaultColorId);
         xpDropTextWidget.setTextColor(color);
     }
 
     private String formatGoldDropText(long goldDropValue)
     {
-        // Format gold value to fit in xp drop to avoid being cutoff by gold sprite
+        // Format gold value to fit in xp drop to avoid being cut off by gold sprite
         // 999
         // 1.0K
         // 20K
@@ -249,7 +251,7 @@ public class ProfitTrackerGoldDrops {
         // 1.0M
 
         float goldValueRep = goldDropValue;
-        String suffix = "";
+        String suffix;
         boolean useDecimal = false;
         if (Math.abs(goldDropValue) < 1000L) { // 1-999
             return Long.toString(goldDropValue);

--- a/src/main/java/com/profittracker/ProfitTrackerGoldDrops.java
+++ b/src/main/java/com/profittracker/ProfitTrackerGoldDrops.java
@@ -337,11 +337,12 @@ public class ProfitTrackerGoldDrops {
         {
             return "ALOT";
         }
+        double resultValue = Long.signum(goldDropValue) * Math.floor(Math.abs(goldValueRep) * 10) / 10;
         if(useDecimal)
         {
-            return String.format("%.1f%s", Math.floor(goldValueRep * 10) / 10, suffix);
+            return String.format("%.1f%s", resultValue, suffix);
         }else{
-            return String.format("%.0f%s", Math.floor(goldValueRep * 10) / 10, suffix);
+            return String.format("%.0f%s", resultValue, suffix);
         }
     }
 }

--- a/src/main/java/com/profittracker/ProfitTrackerGoldDrops.java
+++ b/src/main/java/com/profittracker/ProfitTrackerGoldDrops.java
@@ -173,9 +173,8 @@ public class ProfitTrackerGoldDrops {
             // reset text color for all regular xpdrops
             resetXpDropTextColor(dropTextWidget);
         }
-
-
     }
+
     private void xpDropToGoldDrop(Widget dropTextWidget, Widget dropSpriteWidget, long goldDropValue)
     {
         /*
@@ -184,7 +183,7 @@ public class ProfitTrackerGoldDrops {
 
         if (config.shortDrops()) {
             dropTextWidget.setText(formatGoldDropText(goldDropValue));
-        }else{
+        } else {
             // Remove disabled icon from string
             String formattedValue = dropTextWidget.getText();
             formattedValue = formattedValue.substring(formattedValue.indexOf("> ") + 2);
@@ -213,7 +212,7 @@ public class ProfitTrackerGoldDrops {
                     dropSpriteWidget.setSpriteId(COINS_SPRITE_ID_START - spriteIndex);
                 }
             }
-        }else{
+        } else {
             dropSpriteWidget.setSpriteId(COINS_SPRITE_ID_START - config.iconStyle().ordinal() + 1);
         }
     }
@@ -267,7 +266,14 @@ public class ProfitTrackerGoldDrops {
         String formattedAmount = formatGoldDropText(currentGoldDropValue);
 
         if (config.shortDrops()) {
-            //Use a value to slightly adjust sprite position, as manually setting text later doesn't adjust it
+            /*
+            Modifying the value of xpdrops later can cause substantial dead space between the text and sprite.
+            Passing a value into the runScript for xpdrops will set the sprite position based on the text sent
+            taking up more/less space. The particular character also makes minor adjustments, as the rendering is
+            not a monospace font. This could be eliminated if we can figure out how to reposition the sprite, or
+            eliminate the invisible error icon that causes the dead space, and get the rendered drop to recalculate
+            sprite position based on our custom text.
+             */
             int sizeAdjustingValue = 1;
             sizeAdjustingValue = formattedAmount.length() > 3 ? 6 : sizeAdjustingValue;
             sizeAdjustingValue = formattedAmount.length() > 4 ? 60 : sizeAdjustingValue;
@@ -341,7 +347,7 @@ public class ProfitTrackerGoldDrops {
         if(useDecimal)
         {
             return String.format("%.1f%s", resultValue, suffix);
-        }else{
+        } else {
             return String.format("%.0f%s", resultValue, suffix);
         }
     }

--- a/src/main/java/com/profittracker/ProfitTrackerIconType.java
+++ b/src/main/java/com/profittracker/ProfitTrackerIconType.java
@@ -1,0 +1,15 @@
+package com.profittracker;
+
+public enum ProfitTrackerIconType {
+    DYNAMIC,
+    COINS_1,
+    COINS_2,
+    COINS_3,
+    COINS_4,
+    COINS_5,
+    COINS_25,
+    COINS_100,
+    COINS_250,
+    COINS_1000,
+    COINS_10000
+}

--- a/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
+++ b/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
@@ -426,6 +426,14 @@ public class ProfitTrackerInventoryValue {
      * @return Array of items with quantity set to the difference
      */
     public Item[] getItemCollectionDifference(Item[] originalItems, Item[] newItems){
+        if (config.estimateUntradeables()){
+            //Replace untradeables with their equivalent items.
+            //The replaceUntradeables function is inaccurate for very small amounts, so we need to perform it over the source
+            //with larger quantities instead of over the result difference between collections which generally is just 1 item.
+            //For example, a single stardust = 2/3rds of a soft clay, which is smaller than 1, and so its quantity is truncated by the Item object.
+            originalItems = replaceUntradeables(originalItems);
+            newItems = replaceUntradeables(newItems);
+        }
         Map<Integer, Integer> originalItemList = mapItemArray(originalItems);
         Map<Integer, Integer> newItemList = mapItemArray(newItems);
         //Subtract old quantities from new to get difference

--- a/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
+++ b/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
@@ -4,6 +4,9 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.client.game.ItemManager;
 import org.apache.commons.lang3.ArrayUtils;
+import net.runelite.api.gameval.ItemID;
+import net.runelite.api.gameval.VarbitID;
+import net.runelite.api.gameval.InventoryID;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -21,24 +24,24 @@ public class ProfitTrackerInventoryValue {
     static final int EMPTY_SLOT_ITEMID = -1;
 
     private final int[] RUNE_POUCH_ITEM_IDS = {
-            ItemID.RUNE_POUCH,
-            ItemID.RUNE_POUCH_L,
+            ItemID.BH_RUNE_POUCH,
+            ItemID.BH_RUNE_POUCH_TROUVER,
             ItemID.DIVINE_RUNE_POUCH,
-            ItemID.DIVINE_RUNE_POUCH_L
+            ItemID.DIVINE_RUNE_POUCH_TROUVER
     };
 
     private final int[] RUNE_POUCH_AMOUNT_VARBITS = {
-            Varbits.RUNE_POUCH_AMOUNT1,
-            Varbits.RUNE_POUCH_AMOUNT2,
-            Varbits.RUNE_POUCH_AMOUNT3,
-            Varbits.RUNE_POUCH_AMOUNT4
+            VarbitID.RUNE_POUCH_QUANTITY_1,
+            VarbitID.RUNE_POUCH_QUANTITY_2,
+            VarbitID.RUNE_POUCH_QUANTITY_3,
+            VarbitID.RUNE_POUCH_QUANTITY_4
     };
 
     private final int[] RUNE_POUCH_RUNE_VARBITS = {
-            Varbits.RUNE_POUCH_RUNE1,
-            Varbits.RUNE_POUCH_RUNE2,
-            Varbits.RUNE_POUCH_RUNE3,
-            Varbits.RUNE_POUCH_RUNE4
+            VarbitID.RUNE_POUCH_TYPE_1,
+            VarbitID.RUNE_POUCH_TYPE_2,
+            VarbitID.RUNE_POUCH_TYPE_3,
+            VarbitID.RUNE_POUCH_TYPE_4
     };
 
     private final ItemManager itemManager;
@@ -79,18 +82,16 @@ public class ProfitTrackerInventoryValue {
         log.debug(String.format("calculateItemValue itemId = %d", itemId));
 
         // multiply quantity  by GE value
-        return item.getQuantity() * (itemManager.getItemPrice(itemId));
+        return (long) item.getQuantity() * (itemManager.getItemPrice(itemId));
     }
 
-    public long calculateContainerValue(InventoryID ContainerID)
+    public long calculateContainerValue(int containerID)
     {
         /*
         calculate total inventory value
          */
 
-        long newInventoryValue;
-
-        ItemContainer container = client.getItemContainer(ContainerID);
+        ItemContainer container = client.getItemContainer(containerID);
 
         if (container == null)
         {
@@ -119,7 +120,7 @@ public class ProfitTrackerInventoryValue {
         calculate total inventory value
          */
 
-        return calculateContainerValue(InventoryID.INVENTORY);
+        return calculateContainerValue(InventoryID.INV);
 
     }
 
@@ -128,7 +129,7 @@ public class ProfitTrackerInventoryValue {
         /*
         calculate total equipment value
          */
-        return calculateContainerValue(InventoryID.EQUIPMENT);
+        return calculateContainerValue(InventoryID.WORN);
     }
 
     public long calculateRunePouchValue()
@@ -171,8 +172,8 @@ public class ProfitTrackerInventoryValue {
      * @return Array of items from inventory and equipment containers
      */
     public Item[] getInventoryAndEquipmentContents(){
-        ItemContainer inventoryContainer = client.getItemContainer(InventoryID.INVENTORY);
-        ItemContainer equipmentContainer = client.getItemContainer(InventoryID.EQUIPMENT);
+        ItemContainer inventoryContainer = client.getItemContainer(InventoryID.INV);
+        ItemContainer equipmentContainer = client.getItemContainer(InventoryID.WORN);
 
         if (inventoryContainer == null || equipmentContainer == null)
         {
@@ -197,7 +198,7 @@ public class ProfitTrackerInventoryValue {
     }
 
     public Item[] getGrandExchangeContents(){
-        ArrayList<Item> items = new ArrayList<Item> ();
+        ArrayList<Item> items = new ArrayList<> ();
         //Unclear why, but without an intermediate storage for this variable, just doing items.add(new ...) caused improper quantities
         Item coins;
         for (GrandExchangeOffer offer : offers) {

--- a/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
+++ b/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
@@ -313,21 +313,19 @@ public class ProfitTrackerInventoryValue {
         Item[] extraItems = new Item[0];
         Item[] resultItems = items.clone();
         for (int i = 0; i < resultItems.length; i++){
+            boolean replaceItem = true;
             switch (resultItems[i].getId()){
                 case ItemID.MINNOW:
                     extraItems = ArrayUtils.add(extraItems,new Item(ItemID.RAW_SHARK,resultItems[i].getQuantity() / 40));
-                    resultItems[i] = new Item(-1,0);
                     break;
                 //Mark of grace for amylase crystals seems to be covered already by the GE value checker
                 case ItemID.VARLAMORE_WYRM_AGILITY_TERMITE:
                     extraItems = ArrayUtils.add(extraItems,new Item(ItemID.AMYLASE,resultItems[i].getQuantity()));
-                    resultItems[i] = new Item(-1,0);
                     break;
-                case ItemID.AGILITYARENA_TICKET: //Old agility arena ticker for pirate's hook
+                case ItemID.AGILITYARENA_TICKET: //Old agility arena ticket for pirate's hook
                 case ItemID.AGILITYARENA_VOUCHER: //Brimhaven voucher for pirate's hook
-                    int hookValue = (int) calculateItemValue(new Item(ItemID.PIRATEHOOK, 1));
-                    extraItems = ArrayUtils.add(extraItems,new Item(ItemID.COINS,resultItems[i].getQuantity() * hookValue / 800));
-                    resultItems[i] = new Item(-1,0);
+                    long hookValue = calculateItemValue(new Item(ItemID.PIRATEHOOK, 1));
+                    extraItems = ArrayUtils.add(extraItems,new Item(ItemID.COINS,(int)(resultItems[i].getQuantity() * hookValue / 800)));
                     break;
                 case ItemID.STAR_DUST:
                 case ItemID.STAR_DUST_25:
@@ -335,48 +333,65 @@ public class ProfitTrackerInventoryValue {
                 case ItemID.STAR_DUST_125:
                 case ItemID.STAR_DUST_175:
                     extraItems = ArrayUtils.add(extraItems,new Item(ItemID.SOFTCLAY,resultItems[i].getQuantity() * 2 / 3));
-                    resultItems[i] = new Item(-1,0);
                     break;
                 case ItemID.MOTHERLODE_NUGGET:
                 case ItemID.MGUILD_MINERALS:
                     extraItems = ArrayUtils.add(extraItems,new Item(ItemID.SOFTCLAY,resultItems[i].getQuantity() * 10));
-                    resultItems[i] = new Item(-1,0);
                     break;
                 case ItemID.FORESTRY_CURRENCY: //Anima bark for felling axe handle
-                    int handleValue = (int)(calculateItemValue(new Item(ItemID.FORESTRY_2H_AXE_HANDLE, 1)) - calculateItemValue(new Item(ItemID.OAK_LOGS, 500)));
-                    extraItems = ArrayUtils.add(extraItems,new Item(ItemID.COINS,resultItems[i].getQuantity() * handleValue / 10000));
-                    resultItems[i] = new Item(-1,0);
+                    long handleValue = calculateItemValue(new Item(ItemID.FORESTRY_2H_AXE_HANDLE, 1)) - calculateItemValue(new Item(ItemID.OAK_LOGS, 500));
+                    extraItems = ArrayUtils.add(extraItems,new Item(ItemID.COINS,(int)(resultItems[i].getQuantity() * handleValue / 10000)));
                     break;
                 case ItemID.PRIF_CRYSTAL_SHARD: //Crystal shard high alch
                     extraItems = ArrayUtils.add(extraItems,new Item(ItemID.COINS,resultItems[i].getQuantity() * 6000));
-                    resultItems[i] = new Item(-1,0);
                     break;
                 case ItemID.PRIF_CRYSTAL_SHARD_CRUSHED:
                     // Profit from making divine super combat, used for crystal shards/dust
-                    int potionProfit = (int)(calculateItemValue(new Item(ItemID._4DOSEDIVINECOMBAT, 1)) - calculateItemValue(new Item(ItemID._4DOSE2COMBAT,1)));
-                    extraItems = ArrayUtils.add(extraItems,new Item(ItemID.COINS,resultItems[i].getQuantity() * potionProfit / 4));
-                    resultItems[i] = new Item(-1,0);
+                    long potionProfit = calculateItemValue(new Item(ItemID._4DOSEDIVINECOMBAT, 1)) - calculateItemValue(new Item(ItemID._4DOSE2COMBAT,1));
+                    extraItems = ArrayUtils.add(extraItems,new Item(ItemID.COINS,(int)(resultItems[i].getQuantity() * potionProfit / 4)));
                     break;
                 case ItemID.TZHAAR_TOKEN: //Tokkul for onyx
-                    int onyxValue = (int) calculateItemValue(new Item(ItemID.ONYX, 1));
-                    extraItems = ArrayUtils.add(extraItems,new Item(ItemID.COINS,resultItems[i].getQuantity() * onyxValue / 300000));
-                    resultItems[i] = new Item(-1,0);
+                    long onyxValue = calculateItemValue(new Item(ItemID.ONYX, 1));
+                    extraItems = ArrayUtils.add(extraItems,new Item(ItemID.COINS,(int)(resultItems[i].getQuantity() * onyxValue / 300000)));
                     break;
                 case ItemID.ABYSSAL_PEARL: //Abyssal pearls for ring of the elements
-                    int roteValue = (int) calculateItemValue(new Item(ItemID.RING_OF_ELEMENTS, 1));
-                    extraItems = ArrayUtils.add(extraItems,new Item(ItemID.COINS,resultItems[i].getQuantity() * roteValue / 400));
-                    resultItems[i] = new Item(-1,0);
+                    long roteValue = calculateItemValue(new Item(ItemID.RING_OF_ELEMENTS, 1));
+                    extraItems = ArrayUtils.add(extraItems,new Item(ItemID.COINS,(int)(resultItems[i].getQuantity() * roteValue / 400)));
                     break;
                 case ItemID.VILLAGE_TRADE_STICKS: //Trading sticks for gout tubers
-                    int tuberValue = (int) calculateItemValue(new Item(ItemID.VILLAGE_RARE_TUBER, 1));
-                    extraItems = ArrayUtils.add(extraItems,new Item(ItemID.COINS,resultItems[i].getQuantity() * tuberValue / 120));
-                    resultItems[i] = new Item(-1,0);
+                    long tuberValue = calculateItemValue(new Item(ItemID.VILLAGE_RARE_TUBER, 1));
+                    extraItems = ArrayUtils.add(extraItems,new Item(ItemID.COINS,(int)(resultItems[i].getQuantity() * tuberValue / 120)));
                     break;
                 case ItemID.FOSSIL_MERMAID_TEAR: //Mermaid tears for merfolk trident
-                    int tridentValue = (int) calculateItemValue(new Item(ItemID.MERFOLK_TRIDENT, 1));
-                    extraItems = ArrayUtils.add(extraItems,new Item(ItemID.COINS,resultItems[i].getQuantity() * tridentValue / 400));
-                    resultItems[i] = new Item(-1,0);
+                    long tridentValue = calculateItemValue(new Item(ItemID.MERFOLK_TRIDENT, 1));
+                    extraItems = ArrayUtils.add(extraItems,new Item(ItemID.COINS,(int)(resultItems[i].getQuantity() * tridentValue / 400)));
                     break;
+                case ItemID.KONAR_KEY: //Brimstone key high alch
+                    extraItems = ArrayUtils.add(extraItems,new Item(ItemID.COINS,(int)(resultItems[i].getQuantity() * 48000)));
+                    break;
+                case ItemID.BIRD_EGG_BLUE: //Bird eggs can be traded in for seed nests
+                case ItemID.BIRD_EGG_RED:
+                case ItemID.BIRD_EGG_GREEN:
+                    extraItems = ArrayUtils.add(extraItems,new Item(ItemID.BIRD_NEST_EMPTY,resultItems[i].getQuantity()));
+                    break;
+                case ItemID.BIRD_NEST_EGG_BLUE:
+                case ItemID.BIRD_NEST_EGG_RED:
+                case ItemID.BIRD_NEST_EGG_GREEN:
+                    extraItems = ArrayUtils.add(extraItems,new Item(ItemID.BIRD_NEST_EMPTY,resultItems[i].getQuantity() * 2));
+                    break;
+                case ItemID.MAGIC_IMP_BOX_FULL:
+                case ItemID.MAGIC_IMP_BOX_HALF:
+                    //Replace un-tradeable magic imp boxes with regular ones for value check
+                    //Otherwise using them and opening the bank would cause confusing small profits
+                    extraItems = ArrayUtils.add(extraItems,new Item(ItemID.MAGIC_IMP_BOX,resultItems[i].getQuantity()));
+                    break;
+                //TODO Seedlings: Have unwatered seedlings turn into the seed + pot, and the watered versions into saplings
+                default:
+                    replaceItem = false;
+                    break;
+            }
+            if (replaceItem) {
+                resultItems[i] = new Item(-1,0);
             }
         }
         return ArrayUtils.addAll(resultItems,extraItems);

--- a/src/main/java/com/profittracker/ProfitTrackerOverlay.java
+++ b/src/main/java/com/profittracker/ProfitTrackerOverlay.java
@@ -5,7 +5,6 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
-import net.runelite.client.ui.overlay.components.TooltipComponent;
 import net.runelite.client.ui.overlay.tooltip.Tooltip;
 import net.runelite.client.ui.overlay.tooltip.TooltipManager;
 
@@ -20,6 +19,7 @@ import java.text.DecimalFormat;
 public class ProfitTrackerOverlay extends Overlay {
     private long profitValue;
     private long startTimeMillies;
+    private long activeTicks;
     private boolean inProfitTrackSession;
     private boolean hasBankData;
 
@@ -41,6 +41,7 @@ public class ProfitTrackerOverlay extends Overlay {
         profitValue = 0L;
         ptConfig = config;
         startTimeMillies = 0;
+        activeTicks = 0;
         inProfitTrackSession = false;
         hasBankData = false;
     }
@@ -58,7 +59,11 @@ public class ProfitTrackerOverlay extends Overlay {
 
         if (startTimeMillies > 0)
         {
-            secondsElapsed = (System.currentTimeMillis() - startTimeMillies) / 1000;
+            if (ptConfig.onlineOnlyRate()){
+                secondsElapsed = (long)(activeTicks * 0.6);
+            }else{
+                secondsElapsed = (System.currentTimeMillis() - startTimeMillies) / 1000;
+            }
         }
         else
         {
@@ -142,6 +147,12 @@ public class ProfitTrackerOverlay extends Overlay {
     public void updateStartTimeMillies(final long newValue) {
         SwingUtilities.invokeLater(() ->
                 startTimeMillies = newValue
+        );
+    }
+
+    public void updateActiveTicks() {
+        SwingUtilities.invokeLater(() ->
+                activeTicks += 1
         );
     }
 

--- a/src/main/java/com/profittracker/ProfitTrackerOverlay.java
+++ b/src/main/java/com/profittracker/ProfitTrackerOverlay.java
@@ -1,4 +1,5 @@
 package com.profittracker;
+import com.sun.org.apache.bcel.internal.Const;
 import net.runelite.api.Client;
 import net.runelite.api.MenuAction;
 import net.runelite.client.ui.overlay.Overlay;
@@ -30,6 +31,7 @@ public class ProfitTrackerOverlay extends Overlay {
     private final PanelComponent panelComponent = new PanelComponent();
 
     private static final String RESET_MENU_OPTION = "Reset";
+    private static final Integer MILLISECONDS_PER_TICK = 600;
 
     public static String FormatIntegerWithCommas(long value) {
         DecimalFormat df = new DecimalFormat("###,###,###");
@@ -72,12 +74,12 @@ public class ProfitTrackerOverlay extends Overlay {
         if (startTimeMillies > 0)
         {
             if (ptConfig.onlineOnlyRate()){
-                millisecondsElapsed = (long)(Math.max(0,activeTicks - 1)  * 600);
+                millisecondsElapsed = (long)(Math.max(0, activeTicks - 1)  * MILLISECONDS_PER_TICK);
                 //Add duration since last tick to ensure timer pacing isn't uneven
                 if (lastTickMillies != 0){
                     millisecondsElapsed += System.currentTimeMillis() - lastTickMillies;
                 }
-            }else{
+            } else {
                 millisecondsElapsed = (System.currentTimeMillis() - startTimeMillies);
             }
         }
@@ -201,7 +203,7 @@ public class ProfitTrackerOverlay extends Overlay {
 
         if (showMilliseconds) {
             return String.format("%02d:%02d:%02d.%03d", hr, min, sec, ms);
-        }else{
+        } else {
             return String.format("%02d:%02d:%02d", hr, min, sec);
         }
     }

--- a/src/main/java/com/profittracker/ProfitTrackerOverlay.java
+++ b/src/main/java/com/profittracker/ProfitTrackerOverlay.java
@@ -146,11 +146,11 @@ public class ProfitTrackerOverlay extends Overlay {
     static long calculateProfitHourly(long secondsElapsed, long profit)
     {
         long averageProfitThousandForHour;
-        long averageProfitForSecond;
+        double averageProfitForSecond;
 
         if (secondsElapsed > 0)
         {
-            averageProfitForSecond = (profit) / secondsElapsed;
+            averageProfitForSecond = (double)profit / secondsElapsed;
         }
         else
         {
@@ -158,7 +158,7 @@ public class ProfitTrackerOverlay extends Overlay {
             averageProfitForSecond = 0;
         }
 
-        averageProfitThousandForHour = averageProfitForSecond * 3600 / 1000;
+        averageProfitThousandForHour = (long)(averageProfitForSecond * 3600) / 1000;
 
         return averageProfitThousandForHour;
     }

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -88,7 +88,7 @@ public class ProfitTrackerPlugin extends Plugin
         // Add the inventory overlay
         overlayManager.add(overlay);
 
-        goldDropsObject = new ProfitTrackerGoldDrops(client, itemManager);
+        goldDropsObject = new ProfitTrackerGoldDrops(client, itemManager, config);
 
         inventoryValueObject = new ProfitTrackerInventoryValue(client, itemManager);
 

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -26,7 +26,9 @@ import java.util.Map;
 
 @Slf4j
 @PluginDescriptor(
-        name = "Profit Tracker"
+        name = "Profit Tracker",
+        description = "Tracks profit according to the GE value of your items.",
+        tags = {"overlay"}
 )
 public class ProfitTrackerPlugin extends Plugin
 {
@@ -42,6 +44,7 @@ public class ProfitTrackerPlugin extends Plugin
     private long totalProfit;
 
     private long startTickMillis;
+    private long activeTicks;
 
     private boolean skipTickForProfitCalculation;
     private boolean inventoryValueChanged;
@@ -122,6 +125,7 @@ public class ProfitTrackerPlugin extends Plugin
 
         // this will be filled with actual information in startProfitTrackingSession
         startTickMillis = 0;
+        activeTicks = 0;
 
         // skip profit calculation for first tick, to initialize first inventory value
         skipTickForProfitCalculation = true;
@@ -156,9 +160,17 @@ public class ProfitTrackerPlugin extends Plugin
 
         overlay.updateStartTimeMillies(startTickMillis);
 
+        overlay.updateActiveTicks(activeTicks);
+
         overlay.startSession();
 
         inProfitTrackSession = true;
+    }
+
+    public void resetSession(){
+        initializeVariables();
+        startProfitTrackingSession();
+        inventoryValueChanged = true;
     }
 
     /**
@@ -228,7 +240,8 @@ public class ProfitTrackerPlugin extends Plugin
         }
 
         checkAccount();
-        overlay.updateActiveTicks();
+        activeTicks += 1;
+        overlay.updateActiveTicks(activeTicks);
 
         if (inventoryValueChanged || runePouchContentsChanged || bankValueChanged || grandExchangeValueChanged)
         {

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -181,6 +181,9 @@ public class ProfitTrackerPlugin extends Plugin
                 previousPossessions.grandExchangeItems = null;
             }
         }
+
+        overlay.setBankStatus(previousPossessions.bankItems != null);
+
         previousAccount = accountIdentifier.toString();
     }
 

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -428,6 +428,14 @@ public class ProfitTrackerPlugin extends Plugin
             }
         }
 
+        String[] collectionMenuOptions = {"Collect to bank", "Bank"};
+        for (String collectionMenuOption : collectionMenuOptions) {
+            if (menuOption.startsWith(collectionMenuOption) && grandExchangeOpened) {
+                depositingItem = true;
+                break;
+            }
+        }
+
         // Container items
         // Ignore profit changes for items that act as storage only
         switch (event.getItemId()) {

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -228,6 +228,7 @@ public class ProfitTrackerPlugin extends Plugin
         }
 
         checkAccount();
+        overlay.updateActiveTicks();
 
         if (inventoryValueChanged || runePouchContentsChanged || bankValueChanged || grandExchangeValueChanged)
         {

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -304,6 +304,7 @@ public class ProfitTrackerPlugin extends Plugin
             //Catch untracked storage closing, as tick perfect close can cause onItemContainerChanged to not see the change
             case InterfaceID.HUNTSMANS_KIT:
             case InterfaceID.SEED_VAULT:
+            case InterfaceID.TACKLE_BOX_MAIN:
                 storageJustClosed = true;
                 break;
             case InterfaceID.GE_COLLECT:
@@ -414,9 +415,11 @@ public class ProfitTrackerPlugin extends Plugin
         }
 
         // In these events, inventory WILL be changed, but we DON'T want to calculate profit!
-        if (containerId == InventoryID.HUNTSMANS_KIT || // Huntsman's kit
-            containerId == InventoryID.SEED_VAULT) { // Seed vault
-            skipTickForProfitCalculation = true;
+        switch (containerId){
+            case InventoryID.HUNTSMANS_KIT:
+            case InventoryID.SEED_VAULT:
+            case InventoryID.TACKLE_BOX:
+                skipTickForProfitCalculation = true;
         }
 
         // No container event occurs for the GE collection item containers, but inventory does

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -90,7 +90,7 @@ public class ProfitTrackerPlugin extends Plugin
 
         goldDropsObject = new ProfitTrackerGoldDrops(client, itemManager, config);
 
-        inventoryValueObject = new ProfitTrackerInventoryValue(client, itemManager);
+        inventoryValueObject = new ProfitTrackerInventoryValue(client, itemManager, config);
 
         initializeVariables();
 

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -53,6 +53,8 @@ public class ProfitTrackerPlugin extends Plugin
     private boolean bankJustClosed;
     // Remembers if untracked storage was open last tick, as tick perfect close reports changes late
     private boolean storageJustClosed;
+    // State boolean for when a widget we do not fully track is currently opened, such as the leprechaun tool store
+    private boolean untrackedStorageOpened;
     // Remembers the state of grand exchange
     private boolean grandExchangeOpened;
     // Set when using a deposit menu option. Used to create a depositing deficit for the next time you open bank
@@ -231,7 +233,7 @@ public class ProfitTrackerPlugin extends Plugin
         {
             // Interacting with bank
             // itemContainerChanged does not report bank change if closed on same tick
-            if (storageJustClosed) {
+            if (storageJustClosed || untrackedStorageOpened) {
                 skipTickForProfitCalculation = true;
             }
 
@@ -285,6 +287,10 @@ public class ProfitTrackerPlugin extends Plugin
             case InterfaceID.BANK_DEPOSIT_IMP:
             case InterfaceID.BANK_DEPOSITBOX:
                 depositBoxOpened = true;
+                break;
+            case InterfaceID.FARMING_TOOLS:
+                untrackedStorageOpened = true;
+                break;
         }
     }
 
@@ -309,6 +315,10 @@ public class ProfitTrackerPlugin extends Plugin
                 depositBoxOpened = false;
                 // Negates problems with closing box and depositing same tick
                 depositingItem = true;
+                break;
+            case InterfaceID.FARMING_TOOLS:
+                untrackedStorageOpened = false;
+                storageJustClosed = true;
                 break;
         }
     }

--- a/src/main/java/com/profittracker/ProfitTrackerPossessions.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPossessions.java
@@ -1,0 +1,12 @@
+package com.profittracker;
+import net.runelite.api.Item;
+
+/**
+ * Data structure for holding information about a players possessions
+ * Should be associated with a particular player, or account type like Leagues/Standard/Beta
+ */
+public class ProfitTrackerPossessions {
+    public Item[] inventoryItems;
+    public Item[] bankItems;
+    public Item[] grandExchangeItems;
+}


### PR DESCRIPTION
The primary feature I added was for grand exchange box tracking. Previously, logging in with existing trades, then withdrawing them, would cause profit. Now, the items and coins for offers will count as another storage box. So profit will only be made when under or overpaying for items, or from the GE tax.

The next most notable thing is the ability to convert untradeable items into an equivalent value. So things like getting crystal shards in prif, agility course currencies, mining stardust, and various other things can count for profit. This is based on items they can be traded in for, or converted into.

Aside from that, I fixed and improved a bunch of other things. I did my best to make sure each thing was in separate commits.

## Features
- Added tracking of grand exchange offers
- Added configuration setting toggle for shortening drop values
- Made drop icon adjust dynamically with coin value, along with a config option
- Added function to replace certain untradeables with equivalent items or coins, along with a config option (resolves #8)
- Added a new config option to display rates based on ticks online since session start, instead of total time since session start
- Added a reset menu option for the overlay, accessed via shift + right click (resolves #14)

## Improvements
- Added tooltip warning hover when bank has not been initialized
- Added sections to config to organize settings
- Imp boxes now act like deposit boxes and will no longer desync profit until banking
- Cleaned up behavior for closing banks or storage on the same tick as a container changes

## Fixes
- Fixed switching between accounts in the same session causing interference with profit
- Fixed inaccurate rate calculation for low profit amounts due to loss of precision
- Fixed negative symbol being partially hidden by coin sprite for values formatted to 5 characters long like -1.2K or -100K
- Fixed deposit box usage sometimes causing loss to occur (resolves #24)
- Fixed gold drops always rounding down, instead of towards 0
- Fixed interaction with tool lepreachauns causing profit changes (resolves #15)
- Fixed tackle box counting profit in some cases

## Chores
- Cleaned up item collection difference function (resolves #23)
- Cleaned up various warnings, including deprecated ID usage