### PR TITLE
Attempt to fix plugin hub error on unused bcel.internal.Const import

### DIFF
--- a/src/main/java/com/profittracker/ProfitTrackerOverlay.java
+++ b/src/main/java/com/profittracker/ProfitTrackerOverlay.java
@@ -1,5 +1,4 @@
 package com.profittracker;
-import com.sun.org.apache.bcel.internal.Const;
 import net.runelite.api.Client;
 import net.runelite.api.MenuAction;
 import net.runelite.client.ui.overlay.Overlay;
@@ -31,7 +30,7 @@ public class ProfitTrackerOverlay extends Overlay {
     private final PanelComponent panelComponent = new PanelComponent();
 
     private static final String RESET_MENU_OPTION = "Reset";
-    private static final Integer MILLISECONDS_PER_TICK = 600;
+    private static final int MILLISECONDS_PER_TICK = 600;
 
     public static String FormatIntegerWithCommas(long value) {
         DecimalFormat df = new DecimalFormat("###,###,###");


### PR DESCRIPTION
I don't know if this will fix the issue you ran into with https://github.com/runelite/plugin-hub/pull/8258. But this line wasn't used, and was part of the error message, so maybe it could.

Is there a way I can check for these problems before I make PRs?