### PR TITLE
Remember profit between sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
  
 # Profit Tracker Plugin
 
-This runelite plugin tracks the profit you are generating, according to GE, while money-making.
+This runelite plugin tracks the profit you are generating while money-making. This can be based on GE, alchemy, or shop values.
 ![image](https://user-images.githubusercontent.com/8212109/94357201-5d4c1780-009f-11eb-9c73-17c279edd613.png)
 
 For example, if you are filling vials, the plugin will accumulate profit each time you fill vial, accounting for empty vials price in GE.
@@ -14,8 +14,7 @@ Depositing or withdrawing items will not affect profit value.
 Every change in your inventory, bank, and grand exchange box is monitored and a corresponding profit animation will be shown.
 ![image](https://user-images.githubusercontent.com/8212109/94357070-393c0680-009e-11eb-96a1-8fa7469ee6e1.png)
 
-For example, if you buy in a general shop, an item for 20 coins, which is worth in GE 220 coins,
-ProfitTracker will generate a gold drop animation of 200 coins.
+For example, if you buy in a general shop, an item for 20 coins, which is worth in GE 220 coins, ProfitTracker will generate a gold drop animation of 200 coins.
 
 # How to use
 The plugin will begin tracking when entering the game. The session can be reset by using shift + right-click on the overlay, or by reloading the plugin.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Every change in your inventory, bank, and grand exchange box is monitored and a 
 For example, if you buy in a general shop, an item for 20 coins, which is worth in GE 220 coins, ProfitTracker will generate a gold drop animation of 200 coins.
 
 # How to use
-The plugin will begin tracking when entering the game. The session can be reset by using shift + right-click on the overlay, or by reloading the plugin.
+The plugin will begin tracking when entering the game. The session can be reset or adjusted manually by using shift + right-click on the overlay. Reloading the plugin will also cause a reset.
 
-Certain actions will not be recorded as profit unless the bank has been opened at least once to create a baseline, and again to see changes. Things like using a deposit box to empty storage pouches, or banking items directly from reward chests. So make sure to open up the bank once for better accuracy before doing those things.
+Certain actions will not record profit unless the bank has been opened at least once to create a baseline, and again to see changes. Things like using a deposit box to empty storage pouches, or banking items directly from reward chests. So make sure to open up the bank once for better accuracy before doing those things.
 
 If using the GE, open the bank first so gold withdrawn automatically for trades can be detected and recovered upon opening the bank again.
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 }
 
 group = 'com.profittracker'
-version = '1.6'
+version = '1.7'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/profittracker/ProfitTrackerConfig.java
+++ b/src/main/java/com/profittracker/ProfitTrackerConfig.java
@@ -19,7 +19,7 @@ public interface ProfitTrackerConfig extends Config
             position =  0,
             closedByDefault = false
     )
-    String visualSettings = "Visual";
+    String VISUAL_SETTINGS = "Visual";
 
     @ConfigSection(
             name = "Behavior",
@@ -27,13 +27,21 @@ public interface ProfitTrackerConfig extends Config
             position =  1,
             closedByDefault = false
     )
-    String behaviorSettings = "Behavior";
+    String BEHAVIOR_SETTINGS = "Behavior";
+
+    @ConfigSection(
+            name = "Calculation",
+            description = "Settings for price calculation.",
+            position =  2,
+            closedByDefault = false
+    )
+    String CALCULATION_SETTINGS = "Calculation";
 
     @ConfigItem(
             keyName = "goldDrops",
             name = "Show value changes (gold drops)",
             description = "Show each profit increase or decrease.",
-            section = visualSettings
+            section = VISUAL_SETTINGS
     )
     default boolean goldDrops()
     {
@@ -44,7 +52,7 @@ public interface ProfitTrackerConfig extends Config
             keyName = "unhideGoldDrops",
             name = "Unhide value changes",
             description = "Prevents other plugins from hiding value changes if they are enabled.",
-            section = visualSettings
+            section = VISUAL_SETTINGS
     )
     default boolean unhideGoldDrops()
     {
@@ -55,7 +63,7 @@ public interface ProfitTrackerConfig extends Config
             keyName = "autoStart",
             name = "Automatically start tracking",
             description = "Automatically begin tracking profit on session start.",
-            section = behaviorSettings
+            section = BEHAVIOR_SETTINGS
     )
     default boolean autoStart()
     {
@@ -66,7 +74,7 @@ public interface ProfitTrackerConfig extends Config
             keyName = "rememberProfit",
             name = "Remember profit",
             description = "Profit will be remembered between application closes.",
-            section = behaviorSettings
+            section = BEHAVIOR_SETTINGS
     )
     default boolean rememberProfit()
     {
@@ -77,7 +85,7 @@ public interface ProfitTrackerConfig extends Config
             keyName = "shortDrops",
             name = "Shorten drop numbers",
             description = "Shorten drop numbers like 1.2K instead of 1,223, or 10M instead of 10,000,000.",
-            section = visualSettings
+            section = VISUAL_SETTINGS
     )
     default boolean shortDrops()
     {
@@ -88,7 +96,7 @@ public interface ProfitTrackerConfig extends Config
             keyName = "iconStyle",
             name = "Icon style",
             description = "Dynamically adjust the coin icon based on the drop value, or select a specific icon.",
-            section = visualSettings
+            section = VISUAL_SETTINGS
     )
     default ProfitTrackerIconType iconStyle()
     {
@@ -99,7 +107,7 @@ public interface ProfitTrackerConfig extends Config
             keyName = "estimateUntradeables",
             name = "Estimate untradeable item values",
             description = "Some untradeable items will utilize equivalent values of the best items they can convert into.",
-            section = behaviorSettings
+            section = CALCULATION_SETTINGS
     )
     default boolean estimateUntradeables()
     {
@@ -110,11 +118,23 @@ public interface ProfitTrackerConfig extends Config
             keyName = "onlineOnlyRate",
             name = "Online only rate",
             description = "Show profit rate only for time spent logged in.",
-            section = visualSettings
+            position =  0,
+            section = CALCULATION_SETTINGS
     )
     default boolean onlineOnlyRate()
     {
         return false;
+    }
+
+    @ConfigItem(
+            keyName = "valueMode",
+            name = "Value",
+            description = "Method used to estimate the value of items.",
+            section = CALCULATION_SETTINGS
+    )
+    default ProfitTrackerPriceType valueMode()
+    {
+        return ProfitTrackerPriceType.GE;
     }
 }
 

--- a/src/main/java/com/profittracker/ProfitTrackerConfig.java
+++ b/src/main/java/com/profittracker/ProfitTrackerConfig.java
@@ -5,6 +5,8 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
 
+import java.awt.Color;
+
 /**
  * The ProfitTrackerConfig class is used to provide user preferences to the ProfitTrackerPlugin.
  */
@@ -23,7 +25,7 @@ public interface ProfitTrackerConfig extends Config
 
     @ConfigSection(
             name = "Behavior",
-            description = "Settings for calculation behavior.",
+            description = "Settings for plugin behavior.",
             position =  1,
             closedByDefault = false
     )
@@ -41,7 +43,8 @@ public interface ProfitTrackerConfig extends Config
             keyName = "goldDrops",
             name = "Show value changes (gold drops)",
             description = "Show each profit increase or decrease.",
-            section = VISUAL_SETTINGS
+            section = VISUAL_SETTINGS,
+            position = 0
     )
     default boolean goldDrops()
     {
@@ -52,7 +55,8 @@ public interface ProfitTrackerConfig extends Config
             keyName = "unhideGoldDrops",
             name = "Unhide value changes",
             description = "Prevents other plugins from hiding value changes if they are enabled.",
-            section = VISUAL_SETTINGS
+            section = VISUAL_SETTINGS,
+            position = 1
     )
     default boolean unhideGoldDrops()
     {
@@ -74,7 +78,8 @@ public interface ProfitTrackerConfig extends Config
             keyName = "shortDrops",
             name = "Shorten drop numbers",
             description = "Shorten drop numbers like 1.2K instead of 1,223, or 10M instead of 10,000,000.",
-            section = VISUAL_SETTINGS
+            section = VISUAL_SETTINGS,
+            position = 3
     )
     default boolean shortDrops()
     {
@@ -85,7 +90,8 @@ public interface ProfitTrackerConfig extends Config
             keyName = "iconStyle",
             name = "Icon style",
             description = "Dynamically adjust the coin icon based on the drop value, or select a specific icon.",
-            section = VISUAL_SETTINGS
+            section = VISUAL_SETTINGS,
+            position = 2
     )
     default ProfitTrackerIconType iconStyle()
     {
@@ -96,7 +102,8 @@ public interface ProfitTrackerConfig extends Config
             keyName = "estimateUntradeables",
             name = "Estimate untradeable item values",
             description = "Some untradeable items will utilize equivalent values of the best items they can convert into.",
-            section = CALCULATION_SETTINGS
+            section = CALCULATION_SETTINGS,
+            position = 1
     )
     default boolean estimateUntradeables()
     {
@@ -107,7 +114,7 @@ public interface ProfitTrackerConfig extends Config
             keyName = "onlineOnlyRate",
             name = "Online only rate",
             description = "Show profit rate only for time spent logged in.",
-            position =  0,
+            position =  2,
             section = CALCULATION_SETTINGS
     )
     default boolean onlineOnlyRate()
@@ -119,11 +126,48 @@ public interface ProfitTrackerConfig extends Config
             keyName = "valueMode",
             name = "Value",
             description = "Method used to estimate the value of items.",
-            section = CALCULATION_SETTINGS
+            section = CALCULATION_SETTINGS,
+            position = 0
     )
     default ProfitTrackerPriceType valueMode()
     {
         return ProfitTrackerPriceType.GE;
+    }
+
+    @ConfigItem(
+            keyName = "colorGoldDrops",
+            name = "Color drop text",
+            description = "Change the text color of produced gold drops.",
+            section = VISUAL_SETTINGS,
+            position = 4
+    )
+    default boolean colorGoldDrops()
+    {
+        return false;
+    }
+
+    @ConfigItem(
+            keyName = "colorOnProfit",
+            name = "Profit color",
+            description = "Color of gold drop when positive.",
+            section = VISUAL_SETTINGS,
+            position = 5
+    )
+    default Color colorOnProfit()
+    {
+        return Color.GREEN;
+    }
+
+    @ConfigItem(
+            keyName = "colorOnLoss",
+            name = "Loss color",
+            description = "Color of gold drop when negative.",
+            section = VISUAL_SETTINGS,
+            position = 6
+    )
+    default Color colorOnLoss()
+    {
+        return Color.RED;
     }
 }
 

--- a/src/main/java/com/profittracker/ProfitTrackerConfig.java
+++ b/src/main/java/com/profittracker/ProfitTrackerConfig.java
@@ -60,17 +60,6 @@ public interface ProfitTrackerConfig extends Config
     }
 
     @ConfigItem(
-            keyName = "autoStart",
-            name = "Automatically start tracking",
-            description = "Automatically begin tracking profit on session start.",
-            section = BEHAVIOR_SETTINGS
-    )
-    default boolean autoStart()
-    {
-        return true;
-    }
-
-    @ConfigItem(
             keyName = "rememberProfit",
             name = "Remember profit",
             description = "Profit will be remembered between application closes.",

--- a/src/main/java/com/profittracker/ProfitTrackerConfig.java
+++ b/src/main/java/com/profittracker/ProfitTrackerConfig.java
@@ -8,9 +8,10 @@ import net.runelite.client.config.ConfigSection;
 /**
  * The ProfitTrackerConfig class is used to provide user preferences to the ProfitTrackerPlugin.
  */
-@ConfigGroup("ptconfig")
+@ConfigGroup(ProfitTrackerConfig.GROUP)
 public interface ProfitTrackerConfig extends Config
 {
+    String GROUP = "ptconfig";
 
     @ConfigSection(
             name = "Visual",
@@ -46,6 +47,17 @@ public interface ProfitTrackerConfig extends Config
             section = behaviorSettings
     )
     default boolean autoStart()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "rememberProfit",
+            name = "Remember profit",
+            description = "Profit will be remembered between application closes.",
+            section = behaviorSettings
+    )
+    default boolean rememberProfit()
     {
         return true;
     }

--- a/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
+++ b/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
@@ -56,6 +56,8 @@ public class ProfitTrackerInventoryValue {
             InventoryID.GE_COLLECT_7
     };
 
+    private static final double GE_TAX = 0.02;
+
     private final ItemManager itemManager;
     private final Client client;
     @Inject
@@ -141,15 +143,15 @@ public class ProfitTrackerInventoryValue {
     private int getItemValue(int itemID){
         switch (config.valueMode()){
             case GE_TAXED:
-                return (int) Math.ceil(itemManager.getItemPrice(itemID) * 0.98);
+                return (int) Math.ceil(itemManager.getItemPrice(itemID) * (1 - GE_TAX));
             case LOW_ALCH:
-                return (int) (itemManager.getItemComposition(itemID).getPrice() * 0.4);
+                return (int) (itemManager.getItemComposition(itemID).getPrice() * ProfitTrackerShopValues.COMMON_LOW_ALCH);
             case SHOP_SPECIAL:
-                return (int) (itemManager.getItemComposition(itemID).getPrice() * 0.55);
+                return (int) (itemManager.getItemComposition(itemID).getPrice() * ProfitTrackerShopValues.SPECIAL_55);
             case HIGH_ALCH:
-                return (int) (itemManager.getItemComposition(itemID).getPrice() * 0.6);
+                return (int) (itemManager.getItemComposition(itemID).getPrice() * ProfitTrackerShopValues.SPECIAL_60_HIGH_ALCH);
             case SHOP_OVERSTOCK:
-                return (int) (itemManager.getItemComposition(itemID).getPrice() * 0.1);
+                return (int) (itemManager.getItemComposition(itemID).getPrice() * ProfitTrackerShopValues.MINIMUM_PRICE);
             case GE:
             default:
                 return itemManager.getItemPrice(itemID);

--- a/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
+++ b/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
@@ -222,15 +222,17 @@ public class ProfitTrackerInventoryValue {
     public Item[] getInventoryAndEquipmentContents(){
         ItemContainer inventoryContainer = client.getItemContainer(InventoryID.INV);
         ItemContainer equipmentContainer = client.getItemContainer(InventoryID.WORN);
+        Item[] inventoryItems = new Item[0];
+        Item[] equipmentItems = new Item[0];
 
-        if (inventoryContainer == null || equipmentContainer == null)
-        {
-            return null;
+        if (inventoryContainer != null){
+            inventoryItems = inventoryContainer.getItems();
+        }
+        if (equipmentContainer != null){
+            equipmentItems = equipmentContainer.getItems();
         }
 
-        Item[] inventoryItems = inventoryContainer.getItems();
-        Item[] equipmentItems = equipmentContainer.getItems();
-        Item[] personItems = ArrayUtils.addAll(inventoryItems,equipmentItems);
+        Item[] personItems = ArrayUtils.addAll(inventoryItems, equipmentItems);
         // Expand to have runes from pouch as individual items
         return expandContainers(personItems);
     }

--- a/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
+++ b/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
@@ -61,6 +61,7 @@ public class ProfitTrackerInventoryValue {
     @Inject
     private ProfitTrackerConfig config;
     private GrandExchangeOfferData[] offers = new GrandExchangeOfferData[8];
+    private Item[] collectionBoxItems = new Item[0];
 
     /**
      * Data storage for GE offers as the normal object always maintains a reference,
@@ -93,11 +94,13 @@ public class ProfitTrackerInventoryValue {
     public void setOffers(GrandExchangeOffer[] offers){
         if (offers == null){
             this.offers = new GrandExchangeOfferData[8];
+            this.collectionBoxItems = new Item[0];
             return;
         }
         for (int index = 0; index < offers.length; index++){
             this.offers[index] = new GrandExchangeOfferData(offers[index]);
         }
+        this.collectionBoxItems = getCollectionBoxContents();
     }
 
     private long calculateItemValue(Item item) {
@@ -276,7 +279,7 @@ public class ProfitTrackerInventoryValue {
                     break;
             }
         }
-        return ArrayUtils.addAll(items.toArray(new Item[0]), getCollectionBoxContents());
+        return ArrayUtils.addAll(items.toArray(new Item[0]), collectionBoxItems);
     }
 
     /**
@@ -311,7 +314,7 @@ public class ProfitTrackerInventoryValue {
     /**
      * Replaces various untradeable items with items they can be converted into, or coin values of those items
      */
-    private Item[] replaceUntradeables(Item[] items){
+    public Item[] replaceUntradeables(Item[] items){
         Item[] extraItems = new Item[0];
         Item[] resultItems = items.clone();
         for (int i = 0; i < resultItems.length; i++){
@@ -418,7 +421,6 @@ public class ProfitTrackerInventoryValue {
      */
     private static Map<Integer, Integer> mapItemArray(Item[] items){
         return Arrays.stream(items)
-                .filter((item) -> item.getQuantity() > 0)
                 .collect(Collectors.toMap(Item::getId, Item::getQuantity, Integer::sum));
     }
 
@@ -451,7 +453,7 @@ public class ProfitTrackerInventoryValue {
 
         //Convert back to item array
         List<Item> itemDifference = new ArrayList<>();
-        newItemList.forEach((id, quantity) -> itemDifference.add(new Item(id,quantity)));
+        newItemList.forEach((id, quantity) -> itemDifference.add(new Item(id, quantity)));
 
         return itemDifference.toArray(new Item[0]);
     }
@@ -478,8 +480,18 @@ public class ProfitTrackerInventoryValue {
 
         //Convert back to item array
         List<Item> itemSum = new ArrayList<>();
-        secondItems.forEach((id, quantity) -> itemSum.add(new Item(id,quantity)));
+        secondItems.forEach((id, quantity) -> itemSum.add(new Item(id, quantity)));
 
         return itemSum.toArray(new Item[0]);
+    }
+
+    public static Item[] getItemCollectionGain(Item[] itemDifferences){
+        List<Item> itemGain = new ArrayList<>();
+        mapItemArray(itemDifferences).forEach((id, quantity) -> {
+            if (quantity > 0){
+                itemGain.add(new Item(id, quantity));
+            }
+        });
+        return itemGain.toArray(new Item[0]);
     }
 }

--- a/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
+++ b/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
@@ -132,7 +132,28 @@ public class ProfitTrackerInventoryValue {
         log.debug(String.format("calculateItemValue itemId = %d", itemId));
 
         // multiply quantity  by GE value
-        return (long) item.getQuantity() * (itemManager.getItemPrice(itemId));
+        return (long) item.getQuantity() * (getItemValue(itemId));
+    }
+
+    /**
+     * Returns the value of an item, based on the plugin configs value mode. (GE, high alch, shop, etc.)
+     */
+    private int getItemValue(int itemID){
+        switch (config.valueMode()){
+            case GE_TAXED:
+                return (int) Math.ceil(itemManager.getItemPrice(itemID) * 0.98);
+            case LOW_ALCH:
+                return (int) (itemManager.getItemComposition(itemID).getPrice() * 0.4);
+            case SHOP_SPECIAL:
+                return (int) (itemManager.getItemComposition(itemID).getPrice() * 0.55);
+            case HIGH_ALCH:
+                return (int) (itemManager.getItemComposition(itemID).getPrice() * 0.6);
+            case SHOP_OVERSTOCK:
+                return (int) (itemManager.getItemComposition(itemID).getPrice() * 0.1);
+            case GE:
+            default:
+                return itemManager.getItemPrice(itemID);
+        }
     }
 
     public long calculateContainerValue(int containerID)
@@ -206,7 +227,7 @@ public class ProfitTrackerInventoryValue {
             return 0;
         }
         log.debug(String.format("calculateRuneValue runeId = %d", runeId));
-        return (long)(itemManager.getItemPrice(runePouchEnum.getIntValue(runeId))) * runeQuantity;
+        return (long)(getItemValue(runePouchEnum.getIntValue(runeId))) * runeQuantity;
     }
 
     public long calculateInventoryAndEquipmentValue()
@@ -493,5 +514,16 @@ public class ProfitTrackerInventoryValue {
             }
         });
         return itemGain.toArray(new Item[0]);
+    }
+
+    /**
+     * Returns a more readable string representation of the given item array. Function purely for debugging purposes.
+     */
+    public String printItemCollection(Item[] items){
+        StringBuilder outputString = new StringBuilder();
+        for (Item item : items) {
+            outputString.append(itemManager.getItemComposition(item.getId()).getName() + ", " + item.getQuantity() + "\r\n");
+        }
+        return outputString.toString();
     }
 }

--- a/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
+++ b/src/main/java/com/profittracker/ProfitTrackerInventoryValue.java
@@ -411,6 +411,11 @@ public class ProfitTrackerInventoryValue {
                     //Otherwise using them and opening the bank would cause confusing small profits
                     extraItems = ArrayUtils.add(extraItems,new Item(ItemID.MAGIC_IMP_BOX,resultItems[i].getQuantity()));
                     break;
+                case ItemID.FORESTRY_BASKET_CLOSED:
+                case ItemID.FORESTRY_BASKET_OPEN:
+                    //Forestry basket can be dismantled to return log brace at no cost
+                    extraItems = ArrayUtils.add(extraItems,new Item(ItemID.FORESTRY_STURDY_HARNESS,resultItems[i].getQuantity()));
+                    break;
                 //TODO Seedlings: Have unwatered seedlings turn into the seed + pot, and the watered versions into saplings
                 default:
                     replaceItem = false;

--- a/src/main/java/com/profittracker/ProfitTrackerOverlay.java
+++ b/src/main/java/com/profittracker/ProfitTrackerOverlay.java
@@ -60,7 +60,7 @@ public class ProfitTrackerOverlay extends Overlay {
         ptPlugin = trackerPlugin;
         this.addMenuEntry(MenuAction.RUNELITE_OVERLAY, RESET_MENU_OPTION, "Profit Tracker",menuEntry ->
                 {
-                    ptPlugin.resetSession();
+                    ptPlugin.resetSession(false);
                     profitValue = 0;
                 });
     }
@@ -217,10 +217,10 @@ public class ProfitTrackerOverlay extends Overlay {
         );
     }
 
-    public void setBankStatus(boolean bankReady)
+    public void updateBankStatus(ProfitTrackerRecord accountRecord)
     {
         SwingUtilities.invokeLater(() ->
-                hasBankData = bankReady
+                hasBankData = accountRecord.currentPossessions.bankItems != null
         );
     }
 

--- a/src/main/java/com/profittracker/ProfitTrackerOverlay.java
+++ b/src/main/java/com/profittracker/ProfitTrackerOverlay.java
@@ -1,6 +1,7 @@
 package com.profittracker;
 import net.runelite.api.Client;
 import net.runelite.api.MenuAction;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.LineComponent;
@@ -36,6 +37,7 @@ public class ProfitTrackerOverlay extends Overlay {
     private final PanelComponent panelComponent = new PanelComponent();
 
     private static final String RESET_MENU_OPTION = "Reset";
+    private static final String ADJUST_MENU_OPTION = "Adjust";
     private static final int MILLISECONDS_PER_TICK = 600;
 
     public static String FormatIntegerWithCommas(long value) {
@@ -46,6 +48,8 @@ public class ProfitTrackerOverlay extends Overlay {
     private TooltipManager tooltipManager;
     @Inject
     private Client client;
+    @Inject
+    private ClientThread clientThread;
     @Inject
     private ProfitTrackerOverlay(ProfitTrackerConfig config, ProfitTrackerPlugin trackerPlugin)
     {
@@ -58,11 +62,17 @@ public class ProfitTrackerOverlay extends Overlay {
         inProfitTrackSession = false;
         hasBankData = false;
         ptPlugin = trackerPlugin;
-        this.addMenuEntry(MenuAction.RUNELITE_OVERLAY, RESET_MENU_OPTION, "Profit Tracker",menuEntry ->
+        this.addMenuEntry(MenuAction.RUNELITE_OVERLAY, RESET_MENU_OPTION, "Profit Tracker", menuEntry ->
                 {
                     ptPlugin.resetSession(false);
                     profitValue = 0;
                 });
+        this.addMenuEntry(MenuAction.RUNELITE_OVERLAY, ADJUST_MENU_OPTION, "Profit Tracker", menuEntry ->
+        {
+            clientThread.invoke(ptPlugin::adjustProfit);
+        });
+
+
     }
 
     /**

--- a/src/main/java/com/profittracker/ProfitTrackerOverlay.java
+++ b/src/main/java/com/profittracker/ProfitTrackerOverlay.java
@@ -118,12 +118,11 @@ public class ProfitTrackerOverlay extends Overlay {
         if (!inProfitTrackSession)
         {
             // not in session
-            // notify user to reset plugin in order to start
+            // this should not happen if in game, but we can have it just in case
             panelComponent.getChildren().add(TitleComponent.builder()
-                    .text("Reset plugin to start")
+                    .text("Error")
                     .color(Color.RED)
                     .build());
-
         }
 
         // Show tooltip warning on mouse hover if user hasn't opened bank yet

--- a/src/main/java/com/profittracker/ProfitTrackerOverlay.java
+++ b/src/main/java/com/profittracker/ProfitTrackerOverlay.java
@@ -75,7 +75,7 @@ public class ProfitTrackerOverlay extends Overlay {
             if (ptConfig.onlineOnlyRate()){
                 millisecondsElapsed = (long)(Math.max(0, activeTicks - 1)  * MILLISECONDS_PER_TICK);
                 //Add duration since last tick to ensure timer pacing isn't uneven
-                if (lastTickMillies != 0){
+                if (lastTickMillies != 0 && inProfitTrackSession){
                     millisecondsElapsed += System.currentTimeMillis() - lastTickMillies;
                 }
             } else {
@@ -163,7 +163,10 @@ public class ProfitTrackerOverlay extends Overlay {
      */
     public void updateStartTimeMillies(final long newValue) {
         SwingUtilities.invokeLater(() ->
-                startTimeMillies = newValue
+                {
+                    startTimeMillies = newValue;
+                    lastTickMillies = System.currentTimeMillis();
+                }
         );
     }
 

--- a/src/main/java/com/profittracker/ProfitTrackerOverlay.java
+++ b/src/main/java/com/profittracker/ProfitTrackerOverlay.java
@@ -14,6 +14,9 @@ import javax.swing.*;
 import java.awt.*;
 
 import java.text.DecimalFormat;
+import java.util.Arrays;
+import java.util.Collections;
+
 /**
  * The ProfitTrackerOverlay class is used to display profit values for the user
  */
@@ -26,6 +29,7 @@ public class ProfitTrackerOverlay extends Overlay {
     private boolean hasBankData;
     private String lastTimeDisplay;
     private long lastProfitValue;
+    private int lastWidth;
 
     private final ProfitTrackerConfig ptConfig;
     private final ProfitTrackerPlugin ptPlugin;
@@ -133,9 +137,17 @@ public class ProfitTrackerOverlay extends Overlay {
             tooltipManager.add(new Tooltip(tooltipString));
         }
 
+        String formattedProfit = String.format("%,d",profitValue);
+        String formattedRate = String.format("%,d",profitRateValue) + "K/H";
+        int titleWidth = graphics.getFontMetrics().stringWidth(titleText) + 40;
+        int profitWidth = graphics.getFontMetrics().stringWidth("Profit:    " + formattedProfit);
+        int rateWidth = graphics.getFontMetrics().stringWidth("Rate:    " + formattedRate);
+        // Only allow width to grow, to avoid jitters at high values
+        lastWidth = Collections.max(Arrays.asList(lastWidth, titleWidth, profitWidth, rateWidth));
+
         // Set the size of the overlay (width)
         panelComponent.setPreferredSize(new Dimension(
-                graphics.getFontMetrics().stringWidth(titleText) + 40,
+                lastWidth,
                 0));
 
         // elapsed time
@@ -147,13 +159,13 @@ public class ProfitTrackerOverlay extends Overlay {
         // Profit
         panelComponent.getChildren().add(LineComponent.builder()
                 .left("Profit:")
-                .right(FormatIntegerWithCommas(profitValue))
+                .right(formattedProfit)
                 .build());
 
         // Profit Rate
         panelComponent.getChildren().add(LineComponent.builder()
                 .left("Rate:")
-                .right(profitRateValue + "K/H")
+                .right(formattedRate)
                 .build());
 
         return panelComponent.render(graphics);
@@ -198,7 +210,10 @@ public class ProfitTrackerOverlay extends Overlay {
     public void startSession()
     {
         SwingUtilities.invokeLater(() ->
-                inProfitTrackSession = true
+                {
+                    inProfitTrackSession = true;
+                    lastWidth = 0;
+                }
         );
     }
 

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -259,7 +259,7 @@ public class ProfitTrackerPlugin extends Plugin
 
         if (!inProfitTrackSession)
         {
-            if (accountRecord != null && config.autoStart()){
+            if (accountRecord != null){
                 overlay.startSession();
                 inProfitTrackSession = true;
                 inventoryValueChanged = true;

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -206,7 +206,6 @@ public class ProfitTrackerPlugin extends Plugin
             accountRecord = null;
         }
 
-        //configManager.getRSProfileConfigurationKeys(ProfitTrackerConfig.GROUP,configManager.getRSProfileKey(),"record_");
         if (accountRecord == null) {
             // Check for existing record
             ProfitTrackerRecord record = ProfitTrackerRecord.load(client, configManager, gson);

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -231,7 +231,7 @@ public class ProfitTrackerPlugin extends Plugin
     @Subscribe
     public void onRuneScapeProfileChanged(RuneScapeProfileChanged e)
     {
-        executor.execute(this::checkAccount);
+        checkAccount();
     }
 
     @Override
@@ -239,7 +239,6 @@ public class ProfitTrackerPlugin extends Plugin
     {
         // Remove the inventory overlay
         overlayManager.remove(overlay);
-
     }
 
     @Subscribe

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -315,15 +315,13 @@ public class ProfitTrackerPlugin extends Plugin
             grandExchangeValueChanged = false;
             depositingItem = false;
         }
-        if (closingWidgetId != 0) {
-            setWidgetClosedVariables(closingWidgetId);
-            closingWidgetId = 0;
-        }
+        resetWidgetClosedVariables();
     }
 
     @Subscribe
     public void onWidgetLoaded(WidgetLoaded event)
     {
+        boolean isStorage = true;
         switch (event.getGroupId()) {
             case InterfaceID.BANKMAIN:
                 // Bank contents will be null if the bank has no items when first logging in
@@ -348,6 +346,15 @@ public class ProfitTrackerPlugin extends Plugin
             case InterfaceID.FARMING_TOOLS:
                 untrackedStorageOpened = true;
                 break;
+            default:
+                isStorage = false;
+                break;
+        }
+        if (isStorage) {
+            // If a user is flipping through multiple storages tick after tick, and moving items in/out
+            // tracking can get complicated.
+            // So we reset immediately to avoid longer term desyncs, like jumping between GE and bank
+            resetWidgetClosedVariables();
         }
     }
 
@@ -372,28 +379,31 @@ public class ProfitTrackerPlugin extends Plugin
     }
 
     /**
-     * Clears the associated variable for the tracked storage for the given widget groupID
+     * Clears the associated variable for the last opened storage widget
      * Should be called with closingWidgetId
      */
-    private void setWidgetClosedVariables(int groupId){
-        switch (groupId) {
-            case InterfaceID.BANKMAIN:
-                bankOpened = false;
-                break;
-            case InterfaceID.HUNTSMANS_KIT:
-            case InterfaceID.SEED_VAULT:
-            case InterfaceID.TACKLE_BOX_MAIN:
-            case InterfaceID.FARMING_TOOLS:
-                untrackedStorageOpened = false;
-                break;
-            case InterfaceID.GE_COLLECT:
-            case InterfaceID.GE_OFFERS:
-                grandExchangeOpened = false;
-                break;
-            case InterfaceID.BANK_DEPOSIT_IMP:
-            case InterfaceID.BANK_DEPOSITBOX:
-                depositBoxOpened = false;
-                break;
+    private void resetWidgetClosedVariables(){
+        if (closingWidgetId != 0) {
+            switch (closingWidgetId) {
+                case InterfaceID.BANKMAIN:
+                    bankOpened = false;
+                    break;
+                case InterfaceID.HUNTSMANS_KIT:
+                case InterfaceID.SEED_VAULT:
+                case InterfaceID.TACKLE_BOX_MAIN:
+                case InterfaceID.FARMING_TOOLS:
+                    untrackedStorageOpened = false;
+                    break;
+                case InterfaceID.GE_COLLECT:
+                case InterfaceID.GE_OFFERS:
+                    grandExchangeOpened = false;
+                    break;
+                case InterfaceID.BANK_DEPOSIT_IMP:
+                case InterfaceID.BANK_DEPOSITBOX:
+                    depositBoxOpened = false;
+                    break;
+            }
+            closingWidgetId = 0;
         }
     }
 

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -331,6 +331,7 @@ public class ProfitTrackerPlugin extends Plugin
                     accountRecord.updateBankItems(new Item[0]);
                     overlay.updateBankStatus(accountRecord);
                 }
+                bankOpened = true;
                 break;
             case InterfaceID.GE_COLLECT:
             case InterfaceID.GE_OFFERS:

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -789,9 +789,9 @@ public class ProfitTrackerPlugin extends Plugin
                     accountRecord.itemDifferenceAccumulated = ProfitTrackerInventoryValue.getItemCollectionSum(accountRecord.itemDifferenceAccumulated, coinsAdjustment);
                     accountRecord.profitAccumulated += adjustment;
                     accountRecord.lastPossessionChange = coinsAdjustment;
-                    updateProfitUI();
                     clientThread.invoke(() -> {
-                            goldDropsObject.requestGoldDrop(adjustment);
+                        updateProfitUI();
+                        goldDropsObject.requestGoldDrop(adjustment);
                     });
                 })
                 .build();

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -714,7 +714,6 @@ public class ProfitTrackerPlugin extends Plugin
     public void onScriptPreFired(ScriptPreFired scriptPreFired)
     {
         goldDropsObject.onScriptPreFired(scriptPreFired);
-
     }
 
     @Subscribe
@@ -735,6 +734,18 @@ public class ProfitTrackerPlugin extends Plugin
         // Allows hot swapping between price calculation methods non-destructively
         if (configChanged.getGroup().equals(ProfitTrackerConfig.GROUP)) {
             clientThread.invoke(this::updateProfitUI);
+            clientThread.invoke(() -> {
+                if (config.goldDrops()) {
+                    String[] goldDropVisuals = {"color", "style", "drop"};
+                    for (String containerMenuOption : goldDropVisuals) {
+                        if (configChanged.getKey().toLowerCase().contains(containerMenuOption)) {
+                            // Visual indicator to user when they mess with settings, so they can see
+                            goldDropsObject.requestGoldDrop(0);
+                            break;
+                        }
+                    }
+                }
+            });
         }
     }
 

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -15,6 +15,7 @@ import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ClientShutdown;
+import net.runelite.client.events.PluginChanged;
 import net.runelite.client.events.RuneScapeProfileChanged;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
@@ -53,12 +54,10 @@ public class ProfitTrackerPlugin extends Plugin
     private boolean grandExchangeValueChanged;
     private boolean inProfitTrackSession;
     private boolean runePouchContentsChanged;
-    // Remembers if the bank was open last tick, because tick perfect bank close reports changes late
-    private boolean bankJustClosed;
-    // Remembers if untracked storage was open last tick, as tick perfect close reports changes late
-    private boolean storageJustClosed;
     // State boolean for when a widget we do not fully track is currently opened, such as the leprechaun tool store
     private boolean untrackedStorageOpened;
+    // Remembers the state of bank interface
+    private boolean bankOpened;
     // Remembers the state of grand exchange
     private boolean grandExchangeOpened;
     // Set when using a deposit menu option. Used to create a depositing deficit for the next time you open bank
@@ -67,7 +66,11 @@ public class ProfitTrackerPlugin extends Plugin
     private boolean depositingItem;
     // State of a deposit box being open, used to avoid tracking profit changes when just sending to the bank
     private boolean depositBoxOpened;
-    private long depositDeficit;
+    // Tracks the last widget we care about that closed, like bank, GE, other storage
+    private int closingWidgetId;
+    // Tracks when an event causes an item to be stored to an untracked location, like using an item on a tackle box
+    private boolean depositingUntrackedItem;
+
     private final int[] RUNE_POUCH_VARBITS = {
             VarbitID.RUNE_POUCH_QUANTITY_1,
             VarbitID.RUNE_POUCH_QUANTITY_2,
@@ -139,8 +142,6 @@ public class ProfitTrackerPlugin extends Plugin
         inProfitTrackSession = false;
 
         runePouchContentsChanged = false;
-
-        bankJustClosed = false;
 
         depositingItem = false;
     }
@@ -216,7 +217,6 @@ public class ProfitTrackerPlugin extends Plugin
         totalProfit = accountRecord.profitAccumulated;
         activeTicks = accountRecord.ticksOnline;
         startTickMillis = accountRecord.startTickMillies;
-        depositDeficit = accountRecord.depositDeficit;
 
         overlay.updateProfitValue(totalProfit);
         overlay.updateStartTimeMillies(startTickMillis);
@@ -262,6 +262,10 @@ public class ProfitTrackerPlugin extends Plugin
                 overlay.startSession();
                 inProfitTrackSession = true;
                 inventoryValueChanged = true;
+                // Active ticks will only be 0 if toggling the plugin
+                if (activeTicks == 0) {
+                    resetSession();
+                }
             } else {
                 return;
             }
@@ -277,47 +281,36 @@ public class ProfitTrackerPlugin extends Plugin
 
         if (inventoryValueChanged || runePouchContentsChanged || bankValueChanged || grandExchangeValueChanged)
         {
-            // Interacting with bank
-            // itemContainerChanged does not report bank change if closed on same tick
-            if (storageJustClosed || untrackedStorageOpened) {
-                skipTickForProfitCalculation = true;
-            }
+            tickProfit = calculateProfit();
 
-            tickProfit = calculateTickProfit();
-
-            // accumulate profit
-            if (depositingItem || depositBoxOpened || bankJustClosed){
-                // Track a deficit for deposits because of deposit box problems
-                // Include bank last tick close just to prevent confusing xp drops, even though they re-sync on open
-                depositDeficit += tickProfit;
-                depositingItem = false;
-                tickProfit = 0;
-            }
-
-            // Resync with untracked changes from using deposit box
-            if (bankValueChanged) {
-                tickProfit += depositDeficit;
-                depositDeficit = 0;
-            }
-            accountRecord.depositDeficit = depositDeficit;
-
-            totalProfit += tickProfit;
-            accountRecord.profitAccumulated = totalProfit;
-            overlay.updateProfitValue(totalProfit);
-
-            // generate gold drop
+            // Generate gold drop only based on instantaneous profit, to avoid scaring users during GE adjustment ticks
             if (config.goldDrops() && tickProfit != 0)
             {
                 goldDropsObject.requestGoldDrop(tickProfit);
             }
 
+            totalProfit += tickProfit;
+
+            if (tickProfit != 0) {
+                // This causes total profit to only update when we profit off something.
+                // While this may cause temporary inaccuracy when GE prices change, it prevents excessive calculations
+                // every time an item is moved, equipped, deposited, etc.
+                totalProfit = inventoryValueObject.calculateItemValue(accountRecord.itemDifferenceAccumulated);
+            }
+
+            accountRecord.profitAccumulated = totalProfit;
+            overlay.updateProfitValue(totalProfit);
+
             inventoryValueChanged = false;
             bankValueChanged = false;
             runePouchContentsChanged = false;
             grandExchangeValueChanged = false;
+            depositingItem = false;
         }
-        bankJustClosed = false;
-        storageJustClosed = false;
+        if (closingWidgetId != 0) {
+            setWidgetClosedVariables(closingWidgetId);
+            closingWidgetId = 0;
+        }
     }
 
     @Subscribe
@@ -340,6 +333,9 @@ public class ProfitTrackerPlugin extends Plugin
             case InterfaceID.BANK_DEPOSITBOX:
                 depositBoxOpened = true;
                 break;
+            case InterfaceID.HUNTSMANS_KIT:
+            case InterfaceID.SEED_VAULT:
+            case InterfaceID.TACKLE_BOX_MAIN:
             case InterfaceID.FARMING_TOOLS:
                 untrackedStorageOpened = true;
                 break;
@@ -349,15 +345,37 @@ public class ProfitTrackerPlugin extends Plugin
     @Subscribe
     public void onWidgetClosed(WidgetClosed event)
     {
+        // Widget closes immediately, but items can still transfer between containers the next tick
+        // So actually flagging them is done at the end of the next tick, we just set a variable here to look for later
         switch (event.getGroupId()) {
             case InterfaceID.BANKMAIN:
-                bankJustClosed = true;
-                break;
-            //Catch untracked storage closing, as tick perfect close can cause onItemContainerChanged to not see the change
             case InterfaceID.HUNTSMANS_KIT:
             case InterfaceID.SEED_VAULT:
             case InterfaceID.TACKLE_BOX_MAIN:
-                storageJustClosed = true;
+            case InterfaceID.FARMING_TOOLS:
+            case InterfaceID.GE_COLLECT:
+            case InterfaceID.GE_OFFERS:
+            case InterfaceID.BANK_DEPOSIT_IMP:
+            case InterfaceID.BANK_DEPOSITBOX:
+                closingWidgetId = event.getGroupId();
+                break;
+        }
+    }
+
+    /**
+     * Clears the associated variable for the tracked storage for the given widget groupID
+     * Should be called with closingWidgetId
+     */
+    private void setWidgetClosedVariables(int groupId){
+        switch (groupId) {
+            case InterfaceID.BANKMAIN:
+                bankOpened = false;
+                break;
+            case InterfaceID.HUNTSMANS_KIT:
+            case InterfaceID.SEED_VAULT:
+            case InterfaceID.TACKLE_BOX_MAIN:
+            case InterfaceID.FARMING_TOOLS:
+                untrackedStorageOpened = false;
                 break;
             case InterfaceID.GE_COLLECT:
             case InterfaceID.GE_OFFERS:
@@ -366,17 +384,11 @@ public class ProfitTrackerPlugin extends Plugin
             case InterfaceID.BANK_DEPOSIT_IMP:
             case InterfaceID.BANK_DEPOSITBOX:
                 depositBoxOpened = false;
-                // Negates problems with closing box and depositing same tick
-                depositingItem = true;
-                break;
-            case InterfaceID.FARMING_TOOLS:
-                untrackedStorageOpened = false;
-                storageJustClosed = true;
                 break;
         }
     }
 
-    private long calculateTickProfit()
+    private long calculateProfit()
     {
         /*
         Calculate and return the profit for this tick
@@ -385,7 +397,7 @@ public class ProfitTrackerPlugin extends Plugin
          */
         ProfitTrackerPossessions newPossessions = new ProfitTrackerPossessions();
         newPossessions.grandExchangeItems = null;
-        long newProfit;
+        long newProfit = 0;
         Item[] possessionDifference = null;
 
         // calculate current inventory value
@@ -394,6 +406,7 @@ public class ProfitTrackerPlugin extends Plugin
         if (grandExchangeValueChanged) {
             newPossessions.grandExchangeItems = inventoryValueObject.getGrandExchangeContents();
         }
+        accountRecord.currentPossessions.fillNullItems(newPossessions);
         newPossessions.fillNullItems(accountRecord.currentPossessions);
         Item[] newItems = newPossessions.getItems();
 
@@ -411,31 +424,64 @@ public class ProfitTrackerPlugin extends Plugin
             log.debug("Skipping profit calculation!");
 
             skipTickForProfitCalculation = false;
+        }
 
-            // no profit this tick
-            newProfit = 0;
+        Item[] rawPossessionDifference = new Item[0];
+        if (accountRecord.currentPossessions.getItems() != null) {
+            rawPossessionDifference = ProfitTrackerInventoryValue.getItemCollectionDifference(accountRecord.currentPossessions.getItems(), newItems);
+        }
+        if (rawPossessionDifference.length > 0) {
+            // This block generally checks for possessions changing when they shouldn't be, often when closing storage the same tick as withdraw/depositing
+            // Otherwise, just records the last change seen
+            boolean bankingItemsWithoutWidget = (bankOpened || depositingItem || depositBoxOpened) && inventoryValueObject.getBankContents() == null && !untrackedStorageOpened;
+            // If bank/deposit box/depositing flag, any lost items are in bank, any gained items came from bank
+            if (bankingItemsWithoutWidget) {
+                Item[] bankChange = ProfitTrackerInventoryValue.getItemCollectionDifference(rawPossessionDifference, new Item[0]);
+                newPossessions.bankItems = ProfitTrackerInventoryValue.getItemCollectionSum(accountRecord.currentPossessions.bankItems, bankChange);
+                depositingItem = false;
+            }
+            // If ge opened, gained items pull from ge, items banked will cause temporary desync
+            if (grandExchangeOpened && !grandExchangeValueChanged) {
+                Item[] grandExchangeChange = ProfitTrackerInventoryValue.getItemCollectionDifference(rawPossessionDifference, new Item[0]);
+                newPossessions.grandExchangeItems = ProfitTrackerInventoryValue.getItemCollectionSum(accountRecord.currentPossessions.grandExchangeItems, grandExchangeChange);
+            }
+            // If untracked storage, move lost items to untracked storage, add gained items to old record
+            if (untrackedStorageOpened || depositingUntrackedItem) {
+                depositingUntrackedItem = false;
+                Item[] untrackedStorageChange = ProfitTrackerInventoryValue.getItemCollectionDifference(rawPossessionDifference, new Item[0]);
+                Item[] itemLoss = ProfitTrackerInventoryValue.getItemCollectionGain(untrackedStorageChange);
+                Item[] itemGain = ProfitTrackerInventoryValue.getItemCollectionGain(rawPossessionDifference);
+                newPossessions.untrackedStorageItems = ProfitTrackerInventoryValue.getItemCollectionSum(newPossessions.untrackedStorageItems, untrackedStorageChange);
+                // If we go into the negatives, that means untrackedStorage originally had more items in it
+                Item[] missingItems = ProfitTrackerInventoryValue.getItemCollectionGain(ProfitTrackerInventoryValue.getItemCollectionDifference(newPossessions.untrackedStorageItems, new Item[0]));
+                // Ensure starting possessions has at least as many as were withdrawn
+                accountRecord.startingPossessions.untrackedStorageItems = ProfitTrackerInventoryValue.getItemCollectionSum(accountRecord.startingPossessions.untrackedStorageItems, missingItems);
+                accountRecord.currentPossessions.untrackedStorageItems = ProfitTrackerInventoryValue.getItemCollectionSum(accountRecord.currentPossessions.untrackedStorageItems, missingItems);
+                newPossessions.untrackedStorageItems = ProfitTrackerInventoryValue.getItemCollectionSum(newPossessions.untrackedStorageItems, missingItems);
+            }
+
+            newItems = newPossessions.getItems();
+            // This should always be empty in the event of a storage being opened
+            rawPossessionDifference = ProfitTrackerInventoryValue.getItemCollectionDifference(accountRecord.currentPossessions.getItems(), newItems);
+            if (rawPossessionDifference.length > 0) {
+                accountRecord.lastPossessionChange = rawPossessionDifference;
+                accountRecord.itemDifferenceAccumulated = ProfitTrackerInventoryValue.getItemCollectionSum(accountRecord.itemDifferenceAccumulated, rawPossessionDifference);
+            } else {
+                newProfit = 0;
+            }
         }
 
         // update prevInventoryValue for future calculations anyway!
         //prevInventoryValue = newInventoryValue;
         accountRecord.updateInventoryItems(newPossessions.inventoryItems);
         if (newPossessions.bankItems != null) {
-            if (accountRecord.currentPossessions.bankItems == null) {
-                // If user hasn't opened bank yet, the deficit doesn't help us resync
-                depositDeficit = 0;
-            }
             accountRecord.updateBankItems(newPossessions.bankItems);
             overlay.setBankStatus(accountRecord.currentPossessions.bankItems != null);
         }
         if (newPossessions.grandExchangeItems != null) {
             accountRecord.updateGrandExchangeItems(newPossessions.grandExchangeItems);
         }
-
-        if (newProfit != 0) {
-            Item[] rawPossessionDifference = ProfitTrackerInventoryValue.getItemCollectionDifference(accountRecord.currentPossessions.getItems(), newItems);
-            accountRecord.lastPossessionChange = rawPossessionDifference;
-            accountRecord.itemDifferenceAccumulated = ProfitTrackerInventoryValue.getItemCollectionSum(accountRecord.itemDifferenceAccumulated, rawPossessionDifference);
-        }
+        accountRecord.updateUntrackedItems(newPossessions.untrackedStorageItems);
 
         return newProfit;
     }
@@ -461,16 +507,8 @@ public class ProfitTrackerPlugin extends Plugin
             bankValueChanged = true;
         }
 
-        // In these events, inventory WILL be changed, but we DON'T want to calculate profit!
-        switch (containerId){
-            case InventoryID.HUNTSMANS_KIT:
-            case InventoryID.SEED_VAULT:
-            case InventoryID.TACKLE_BOX:
-                skipTickForProfitCalculation = true;
-        }
-
         // No container event occurs for the GE collection item containers, but inventory does
-        if (grandExchangeOpened) {
+        if (grandExchangeOpened && closingWidgetId != InterfaceID.GE_OFFERS && closingWidgetId != InterfaceID.GE_COLLECT) {
             inventoryValueObject.setOffers(client.getGrandExchangeOffers());
             grandExchangeValueChanged = true;
         }
@@ -479,7 +517,7 @@ public class ProfitTrackerPlugin extends Plugin
     @Subscribe
     public void onGrandExchangeOfferChanged(GrandExchangeOfferChanged event)
     {
-        if (grandExchangeOpened){
+        if (grandExchangeOpened && closingWidgetId != InterfaceID.GE_OFFERS && closingWidgetId != InterfaceID.GE_COLLECT){
             inventoryValueObject.setOffers(client.getGrandExchangeOffers());
             grandExchangeValueChanged = true;
         }
@@ -544,7 +582,7 @@ public class ProfitTrackerPlugin extends Plugin
                     case "use":
                         log.debug("Ignoring storage item interaction.");
                         // Ignore manual changes to container items as the items have not been lost
-                        skipTickForProfitCalculation = true;
+                        depositingUntrackedItem = true;
                 }
         }
 
@@ -569,7 +607,6 @@ public class ProfitTrackerPlugin extends Plugin
                     case "empty":
                     case "fill":
                     case "use":
-                        // Ignore manual changes to container items as the items have not been lost
                         skipTickForProfitCalculation = false;
                 }
         }

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -21,7 +21,6 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.api.events.VarbitChanged;
-import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.Arrays;
 import java.util.concurrent.ScheduledExecutorService;
@@ -176,7 +175,7 @@ public class ProfitTrackerPlugin extends Plugin
         inventoryValueChanged = true;
         if (accountRecord != null) {
             accountRecord.reset(configManager);
-            accountRecord.save(configManager, gson);
+            accountRecord.save(gson);
         }
     }
 
@@ -194,7 +193,7 @@ public class ProfitTrackerPlugin extends Plugin
 
         if (previousAccount != null && changedAccounts) {
             // Changed account, save the items we know about
-            accountRecord.save(configManager, gson);
+            accountRecord.save(gson);
             accountRecord = null;
         }
 
@@ -384,37 +383,25 @@ public class ProfitTrackerPlugin extends Plugin
         if skipTickForProfitCalculation is set, meaning this tick was bank / deposit
         so return 0
          */
-        Item[] newInventoryItems;
-        Item[] newBankItems;
-        Item[] newGrandExchangeItems = null;
+        ProfitTrackerPossessions newPossessions = new ProfitTrackerPossessions();
+        newPossessions.grandExchangeItems = null;
         long newProfit;
         Item[] possessionDifference = null;
-        Item[] bankDifference;
-        Item[] grandExchangeDifference;
 
         // calculate current inventory value
-        newInventoryItems = inventoryValueObject.getInventoryAndEquipmentContents();
-        newBankItems = inventoryValueObject.getBankContents();
+        newPossessions.inventoryItems = inventoryValueObject.getInventoryAndEquipmentContents();
+        newPossessions.bankItems = inventoryValueObject.getBankContents();
         if (grandExchangeValueChanged) {
-            newGrandExchangeItems = inventoryValueObject.getGrandExchangeContents();
+            newPossessions.grandExchangeItems = inventoryValueObject.getGrandExchangeContents();
         }
+        newPossessions.fillNullItems(accountRecord.currentPossessions);
+        Item[] newItems = newPossessions.getItems();
 
-        if (!skipTickForProfitCalculation && accountRecord.currentPossessions.inventoryItems != null && newInventoryItems != null)
+        if (!skipTickForProfitCalculation && accountRecord.currentPossessions.inventoryItems != null && newItems != null)
         {
             // calculate new profit
-            possessionDifference = inventoryValueObject.getItemCollectionDifference(accountRecord.currentPossessions.inventoryItems,newInventoryItems);
+            possessionDifference = inventoryValueObject.getItemCollectionDifference(accountRecord.currentPossessions.getItems(), newItems, config.estimateUntradeables());
             newProfit = inventoryValueObject.calculateItemValue(possessionDifference);
-            if (accountRecord.currentPossessions.bankItems != null && newBankItems != null) {
-                bankDifference = inventoryValueObject.getItemCollectionDifference(accountRecord.currentPossessions.bankItems,newBankItems);
-                // Profit is recalculated on all items instead of summed just in case item values could change between calculations
-                possessionDifference = ArrayUtils.addAll(possessionDifference,bankDifference);
-                newProfit = inventoryValueObject.calculateItemValue(possessionDifference);
-            }
-            if (accountRecord.currentPossessions.grandExchangeItems != null && newGrandExchangeItems != null) {
-                grandExchangeDifference = inventoryValueObject.getItemCollectionDifference(accountRecord.currentPossessions.grandExchangeItems,newGrandExchangeItems);
-                possessionDifference = ArrayUtils.addAll(possessionDifference,grandExchangeDifference);
-                newProfit = inventoryValueObject.calculateItemValue(possessionDifference);
-            }
 
             log.debug("Calculated " + newProfit + " profit for " + (possessionDifference.length) + " item changes.");
         }
@@ -431,21 +418,23 @@ public class ProfitTrackerPlugin extends Plugin
 
         // update prevInventoryValue for future calculations anyway!
         //prevInventoryValue = newInventoryValue;
-        accountRecord.updateInventoryItems(newInventoryItems);
-        if (newBankItems != null) {
+        accountRecord.updateInventoryItems(newPossessions.inventoryItems);
+        if (newPossessions.bankItems != null) {
             if (accountRecord.currentPossessions.bankItems == null) {
                 // If user hasn't opened bank yet, the deficit doesn't help us resync
                 depositDeficit = 0;
             }
-            accountRecord.updateBankItems(newBankItems);
+            accountRecord.updateBankItems(newPossessions.bankItems);
             overlay.setBankStatus(accountRecord.currentPossessions.bankItems != null);
         }
-        if (newGrandExchangeItems != null) {
-            accountRecord.updateGrandExchangeItems(newGrandExchangeItems);
+        if (newPossessions.grandExchangeItems != null) {
+            accountRecord.updateGrandExchangeItems(newPossessions.grandExchangeItems);
         }
 
         if (newProfit != 0) {
-            accountRecord.lastPossessionChange = possessionDifference;
+            Item[] rawPossessionDifference = ProfitTrackerInventoryValue.getItemCollectionDifference(accountRecord.currentPossessions.getItems(), newItems);
+            accountRecord.lastPossessionChange = rawPossessionDifference;
+            accountRecord.itemDifferenceAccumulated = ProfitTrackerInventoryValue.getItemCollectionSum(accountRecord.itemDifferenceAccumulated, rawPossessionDifference);
         }
 
         return newProfit;
@@ -687,6 +676,6 @@ public class ProfitTrackerPlugin extends Plugin
     @Subscribe
     public void onClientShutdown(ClientShutdown event)
     {
-        accountRecord.save(configManager, gson);
+        accountRecord.save(gson);
     }
 }

--- a/src/main/java/com/profittracker/ProfitTrackerPossessions.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPossessions.java
@@ -1,5 +1,6 @@
 package com.profittracker;
 import net.runelite.api.Item;
+import static com.profittracker.ProfitTrackerInventoryValue.getItemCollectionSum;
 
 /**
  * Data structure for holding information about a players possessions
@@ -9,4 +10,24 @@ public class ProfitTrackerPossessions {
     public Item[] inventoryItems;
     public Item[] bankItems;
     public Item[] grandExchangeItems;
+
+    public Item[] getItems(){
+        Item[] storedItems = getItemCollectionSum(bankItems, grandExchangeItems);
+        return getItemCollectionSum(inventoryItems, storedItems);
+    }
+
+    /**
+     * If any collection is null, it will instead use the items from the given possessions
+     */
+    public void fillNullItems(ProfitTrackerPossessions knownPossessions){
+        if (inventoryItems == null){
+            inventoryItems = knownPossessions.inventoryItems;
+        }
+        if (bankItems == null){
+            bankItems = knownPossessions.bankItems;
+        }
+        if (grandExchangeItems == null){
+            grandExchangeItems = knownPossessions.grandExchangeItems;
+        }
+    }
 }

--- a/src/main/java/com/profittracker/ProfitTrackerPossessions.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPossessions.java
@@ -10,9 +10,16 @@ public class ProfitTrackerPossessions {
     public Item[] inventoryItems;
     public Item[] bankItems;
     public Item[] grandExchangeItems;
+    /**
+     * Items stored in various storage that we don't actually have hooks to look into
+     * Items are stored here if one of those storages is opened, and an item is lost
+     * Items should also be stored in the original possessions if withdrawn and not previously known to be present
+     */
+    public Item[] untrackedStorageItems;
 
     public Item[] getItems(){
         Item[] storedItems = getItemCollectionSum(bankItems, grandExchangeItems);
+        storedItems = getItemCollectionSum(untrackedStorageItems, storedItems);
         return getItemCollectionSum(inventoryItems, storedItems);
     }
 
@@ -28,6 +35,9 @@ public class ProfitTrackerPossessions {
         }
         if (grandExchangeItems == null){
             grandExchangeItems = knownPossessions.grandExchangeItems;
+        }
+        if (untrackedStorageItems == null){
+            untrackedStorageItems = knownPossessions.untrackedStorageItems;
         }
     }
 }

--- a/src/main/java/com/profittracker/ProfitTrackerPriceType.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPriceType.java
@@ -3,10 +3,10 @@ package com.profittracker;
 public enum ProfitTrackerPriceType {
     GE("Grand Exchange"),
     GE_TAXED("Grand Exchange (2% Tax)"), //98% rounded up
-    HIGH_ALCH("High Alchemy / Shop++"), //60%, wildy shop, rogues den
-    SHOP_SPECIAL("Shop+"), //55%, west ardy, pollnivneach, legends' guild general stores
-    LOW_ALCH("Low Alchemy / Shop"), //40%, regular general stores
-    SHOP_OVERSTOCK("Shop (Overstocked)"); //10%
+    HIGH_ALCH("High Alchemy / Shop 60%"), //60%, wildy shop, rogues den
+    SHOP_SPECIAL("Shop 55%"), //55%, west ardy, pollnivneach, legends' guild general stores, moon clan, lighthouse
+    LOW_ALCH("Low Alchemy / Shop 40%"), //40%, regular general stores
+    SHOP_OVERSTOCK("Shop 10% (Overstocked)"); //10%
 
     private final String name;
 

--- a/src/main/java/com/profittracker/ProfitTrackerPriceType.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPriceType.java
@@ -1,0 +1,22 @@
+package com.profittracker;
+
+public enum ProfitTrackerPriceType {
+    GE("Grand Exchange"),
+    GE_TAXED("Grand Exchange (2% Tax)"), //98% rounded up
+    HIGH_ALCH("High Alchemy / Shop++"), //60%, wildy shop, rogues den
+    SHOP_SPECIAL("Shop+"), //55%, west ardy, pollnivneach, legends' guild general stores
+    LOW_ALCH("Low Alchemy / Shop"), //40%, regular general stores
+    SHOP_OVERSTOCK("Shop (Overstocked)"); //10%
+
+    private final String name;
+
+    ProfitTrackerPriceType(String s) {
+        name = s;
+    }
+
+    @Override
+    public String toString()
+    {
+        return name;
+    }
+}

--- a/src/main/java/com/profittracker/ProfitTrackerRecord.java
+++ b/src/main/java/com/profittracker/ProfitTrackerRecord.java
@@ -40,11 +40,20 @@ public class ProfitTrackerRecord {
         currentPossessions = new ProfitTrackerPossessions();
     }
 
-    public void reset(ConfigManager configManager) {
+    /**
+     * Clears record data. Current possessions are not cleared, unless a hard reset is performed.
+     * This is to allow resetting without having to open bank/ge again to learn items.
+     * Hard resets are needed to avoid users turning off the plugin, gaining items, then enabling it,
+     * and instantly getting profit when opening bank or GE.
+     */
+    public void reset(ConfigManager configManager, boolean hardReset) {
         startTickMillies = System.currentTimeMillis();
         ticksOnline = 0;
         profitAccumulated = 0;
         startingPossessions = new ProfitTrackerPossessions();
+        if (hardReset) {
+            currentPossessions = new ProfitTrackerPossessions();
+        }
         itemDifferenceAccumulated = new Item[0];
     }
 

--- a/src/main/java/com/profittracker/ProfitTrackerRecord.java
+++ b/src/main/java/com/profittracker/ProfitTrackerRecord.java
@@ -1,0 +1,142 @@
+package com.profittracker;
+
+import com.google.gson.Gson;
+import net.runelite.api.Client;
+import net.runelite.api.Item;
+import net.runelite.client.RuneLite;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.config.RuneScapeProfileType;
+
+import java.io.File;
+import java.nio.file.Files;
+
+/**
+ * Long term data storage for individual account profiles
+ */
+public class ProfitTrackerRecord {
+    public String name;
+    public RuneScapeProfileType rsProfileType;
+    public long hash;
+    public long startTickMillies;
+    public long ticksOnline;
+    public long profitAccumulated;
+    public long depositDeficit;
+    public ProfitTrackerPossessions startingPossessions;
+    public ProfitTrackerPossessions currentPossessions;
+    public Item[] lastPossessionChange;
+
+    public static final File RECORD_DIRECTORY = new File(RuneLite.RUNELITE_DIR, "profit-tracker");
+
+    public ProfitTrackerRecord(Client client){
+        hash = client.getAccountHash();
+        rsProfileType = RuneScapeProfileType.getCurrent(client);
+        startTickMillies = System.currentTimeMillis();
+        ticksOnline = 0;
+        profitAccumulated = 0;
+        depositDeficit = 0;
+        startingPossessions = new ProfitTrackerPossessions();
+        currentPossessions = new ProfitTrackerPossessions();
+    }
+
+    public void reset(ConfigManager configManager) {
+        startTickMillies = System.currentTimeMillis();
+        ticksOnline = 0;
+        profitAccumulated = 0;
+        startingPossessions = new ProfitTrackerPossessions();
+    }
+
+    public void updateInventoryItems(Item[] items){
+        if (startingPossessions.inventoryItems == null) {
+            startingPossessions.inventoryItems = items;
+        }
+        currentPossessions.inventoryItems = items;
+    }
+
+    public void updateBankItems(Item[] items){
+        if (startingPossessions.bankItems == null) {
+            startingPossessions.bankItems = items;
+        }
+        currentPossessions.bankItems = items;
+    }
+
+    public void updateGrandExchangeItems(Item[] items){
+        if (startingPossessions.grandExchangeItems == null) {
+            startingPossessions.grandExchangeItems = items;
+        }
+        currentPossessions.grandExchangeItems = items;
+    }
+
+    public String getAccountRecordKey(){
+        return createAccountRecordKey(this.hash,this.rsProfileType.name());
+    }
+
+    private static String createAccountRecordKey(long accountHash, String rsProfileType) {
+        if (accountHash == -1) {
+            // Not logged in
+            return null;
+        }
+        // Account for special worlds where a player with the same name might have different possessions
+        // For example, a speedrunning world has MEMBER and SPEEDRUNNING types
+        String accountIdentifier = Long.toString(accountHash) + "_" + rsProfileType;
+        return "record_" + accountIdentifier;
+    }
+
+    public static String getAccountRecordKey(Client client){
+        return createAccountRecordKey(client.getAccountHash(), RuneScapeProfileType.getCurrent(client).name());
+    }
+
+    private static File getAccountRecordFile(Client client){
+        return new File(RECORD_DIRECTORY, getAccountRecordKey(client) + ".json");
+    }
+
+    private File getAccountRecordFile(){
+        return new File(RECORD_DIRECTORY, getAccountRecordKey() + ".json");
+    }
+
+    /**
+     * Loads the current accounts record from its expected file location
+     * Returns null if anything fails
+     */
+    public static ProfitTrackerRecord load(Client client, ConfigManager configManager, Gson gson){
+        String json;
+        try {
+            json = new String(Files.readAllBytes(getAccountRecordFile(client).toPath()));
+        } catch(Exception e) {
+            return null;
+        }
+        try {
+            return gson.fromJson(json, ProfitTrackerRecord.class);
+        } catch(Exception e) {
+            // Likely failed to read, maybe the data was corrupted, or manually modified
+            return null;
+        }
+    }
+
+    /**
+     * Saves the current account data into a json file by the name of the account hash + rs profile type
+     */
+    public void save(ConfigManager configManager, Gson gson){
+        String json = gson.toJson(this);
+
+        File accountFile = getAccountRecordFile();
+        try {
+            tryCreateRecordFolder();
+            Files.write(accountFile.toPath(), json.getBytes());
+        } catch(Exception ignored) {
+        }
+    }
+
+    /**
+     * Removes stored data for this item, for when users don't want to track across sessions
+     */
+    public void clear(ConfigManager configManager, ProfitTrackerConfig config){
+        configManager.unsetConfiguration(ProfitTrackerConfig.GROUP,configManager.getRSProfileKey(),getAccountRecordKey());
+    }
+
+    private void tryCreateRecordFolder() {
+        if (!RECORD_DIRECTORY.exists())
+        {
+            RECORD_DIRECTORY.mkdir();
+        }
+    }
+}

--- a/src/main/java/com/profittracker/ProfitTrackerRecord.java
+++ b/src/main/java/com/profittracker/ProfitTrackerRecord.java
@@ -20,15 +20,13 @@ public class ProfitTrackerRecord {
     public long startTickMillies;
     public long ticksOnline;
     public long profitAccumulated;
-    public long depositDeficit;
     public ProfitTrackerPossessions startingPossessions;
     public ProfitTrackerPossessions currentPossessions;
     public Item[] lastPossessionChange;
     /**
-     * A sum of all item changes observed. Similar to difference between starting and current possessions.
-     * However, various untracked storage will cause that to be less accurate.
+     * A sum of all item changes observed. Ideally the same as the difference between starting and current possessions.
      */
-    public Item[] itemDifferenceAccumulated;
+    public Item[] itemDifferenceAccumulated = new Item[0];
 
     public static final File RECORD_DIRECTORY = new File(RuneLite.RUNELITE_DIR, "profit-tracker");
 
@@ -38,7 +36,6 @@ public class ProfitTrackerRecord {
         startTickMillies = System.currentTimeMillis();
         ticksOnline = 0;
         profitAccumulated = 0;
-        depositDeficit = 0;
         startingPossessions = new ProfitTrackerPossessions();
         currentPossessions = new ProfitTrackerPossessions();
     }
@@ -70,6 +67,13 @@ public class ProfitTrackerRecord {
             startingPossessions.grandExchangeItems = items;
         }
         currentPossessions.grandExchangeItems = items;
+    }
+
+    public void updateUntrackedItems(Item[] items){
+        if (startingPossessions.untrackedStorageItems == null) {
+            startingPossessions.untrackedStorageItems = items;
+        }
+        currentPossessions.untrackedStorageItems = items;
     }
 
     public String getAccountRecordKey(){

--- a/src/main/java/com/profittracker/ProfitTrackerRecord.java
+++ b/src/main/java/com/profittracker/ProfitTrackerRecord.java
@@ -60,6 +60,18 @@ public class ProfitTrackerRecord {
         itemDifferenceAccumulated = new Item[0];
     }
 
+    public void updateItems(ProfitTrackerPossessions newPossessions, ProfitTrackerOverlay overlay){
+        this.updateInventoryItems(newPossessions.inventoryItems);
+        if (newPossessions.bankItems != null) {
+            this.updateBankItems(newPossessions.bankItems);
+            overlay.updateBankStatus(this);
+        }
+        if (newPossessions.grandExchangeItems != null) {
+            this.updateGrandExchangeItems(newPossessions.grandExchangeItems);
+        }
+        this.updateUntrackedItems(newPossessions.untrackedStorageItems);
+    }
+
     public void updateInventoryItems(Item[] items){
         if (startingPossessions.inventoryItems == null) {
             startingPossessions.inventoryItems = items;

--- a/src/main/java/com/profittracker/ProfitTrackerRecord.java
+++ b/src/main/java/com/profittracker/ProfitTrackerRecord.java
@@ -25,6 +25,7 @@ public class ProfitTrackerRecord {
     public Item[] lastPossessionChange;
     /**
      * A sum of all item changes observed. Ideally the same as the difference between starting and current possessions.
+     * Can change if the user decides to adjust manually.
      */
     public Item[] itemDifferenceAccumulated = new Item[0];
 
@@ -38,6 +39,7 @@ public class ProfitTrackerRecord {
         profitAccumulated = 0;
         startingPossessions = new ProfitTrackerPossessions();
         currentPossessions = new ProfitTrackerPossessions();
+        lastPossessionChange = null;
     }
 
     /**
@@ -54,6 +56,7 @@ public class ProfitTrackerRecord {
         if (hardReset) {
             currentPossessions = new ProfitTrackerPossessions();
         }
+        lastPossessionChange = null;
         itemDifferenceAccumulated = new Item[0];
     }
 

--- a/src/main/java/com/profittracker/ProfitTrackerRecord.java
+++ b/src/main/java/com/profittracker/ProfitTrackerRecord.java
@@ -24,6 +24,11 @@ public class ProfitTrackerRecord {
     public ProfitTrackerPossessions startingPossessions;
     public ProfitTrackerPossessions currentPossessions;
     public Item[] lastPossessionChange;
+    /**
+     * A sum of all item changes observed. Similar to difference between starting and current possessions.
+     * However, various untracked storage will cause that to be less accurate.
+     */
+    public Item[] itemDifferenceAccumulated;
 
     public static final File RECORD_DIRECTORY = new File(RuneLite.RUNELITE_DIR, "profit-tracker");
 
@@ -43,6 +48,7 @@ public class ProfitTrackerRecord {
         ticksOnline = 0;
         profitAccumulated = 0;
         startingPossessions = new ProfitTrackerPossessions();
+        itemDifferenceAccumulated = new Item[0];
     }
 
     public void updateInventoryItems(Item[] items){
@@ -115,7 +121,7 @@ public class ProfitTrackerRecord {
     /**
      * Saves the current account data into a json file by the name of the account hash + rs profile type
      */
-    public void save(ConfigManager configManager, Gson gson){
+    public void save(Gson gson){
         String json = gson.toJson(this);
 
         File accountFile = getAccountRecordFile();

--- a/src/main/java/com/profittracker/ProfitTrackerShopValues.java
+++ b/src/main/java/com/profittracker/ProfitTrackerShopValues.java
@@ -1,0 +1,14 @@
+package com.profittracker;
+
+//See https://oldschool.runescape.wiki/w/General_store
+public class ProfitTrackerShopValues {
+    public static final double RASOLO = 0.05;
+    public static final double MINIMUM_PRICE = 0.1; //Lowest the price can supposedly drop when overstocking a shop
+    public static final double CANIFIS = 0.1;
+    public static final double STAN = 0.15;
+    public static final double DWARVEN = 0.3;
+    public static final double COMMON_LOW_ALCH = 0.4; //Most general stores
+    public static final double SPECIAL_50 = 0.5; //At least 4 different shops
+    public static final double SPECIAL_55 = 0.55; //At least 8 different shops
+    public static final double SPECIAL_60_HIGH_ALCH = 0.6; //At least 4 different shops
+}


### PR DESCRIPTION
I implement record keeping for when runelite gets shutdown and people want to continue tracking profit into the next session. I ended up not doing the config file method, and instead utilized a new directory for storing jsons, which I also saw a couple other plugins do to store their data. This was because using config was very confusing, often not updating, or having different data than what was shown in the file. Also, the amount of data stored for profit tracker seems to be a lot more than other things in the config. There is a config setting to turn it on/off though.

I implemented it in a way that lets toggling the plugin mid-game still reset it, as we don't have a side panel yet to make resetting really discoverable. This should help avoid existing users suddenly getting confused.

The way the profit it accumulated is now based on a collection of accumulated item changes instead of just incrementing a number. This allows adjustments of the total value as GE prices change, enabling usage of the plugin for merching, and generally improving accuracy over longer sessions. It also enables non-destructive swapping of the value estimate between GE, alch, or shop prices. This collection would be a good thing to display when we get a side panel. 

Fixed a few other things related to large profit or profit rates, especially now that profit has the opportunity to grow far longer with multiple sessions.

Fixed up several things relating to gold drops being interfered with by other plugins. With this, the old ugly code to modify the sprite position is gone, and it now makes a lot more sense, actually measures the text, and aligns to even single digit values properly. Really glad to finally figure that one out.

### Features
- Multi-session tracking, each RS account profile tracks individually, and saves data to a json file (resolves #28 )
- GE price fluctuations are now tracked on item changes observed since the start of the session
- New setting to control the source of item prices, enabling accounts like ironmen to still use the plugin for alch or shop prices
- Added manual adjustment option in shift + right-click menu (resolves #31 )
- Drop text color can be configured, and toggled on/off

### Fixes
- Fixed problems tracking profit when no items equipped, or when first depositing into an empty bank
- Fixed issues with closing GE offers too fast causing profit
- Fixed certain deposit timings and methods causing deposited items to be sensitive to GE price fluctuations
- Gold sprite position is correctly aligned with all values, regardless of text length
- Fixed drop text coloring being overwritten by other plugins like the xp drop plugin

### Improvements
- Limited rate update frequency to reduce visual noise, and improve readability for high rates
- Added comma usage for rate display to break up large rates
- Overlay now grows in size with larger rates to avoid text overlapping
- Overlay will now update instantly when modifying settings, particularly the ones in the new calculation section
- Modifying gold drop related visual settings will now produce an example gold drop of 0 to allow users to see visual changes immediately
- Default drop value is now always the actual positive value, ensuring other plugins that do not pull our modified data still display something useful
- Added forestry basket to untradeable conversion as sturdy harness is recoverable

### Changes
- Removed autostart setting in favor of always autostarting, as having it off is pointless friction to users, and causes problems with toggling