### PR TITLE
New config option to address other plugins hiding our gold drops

### DIFF
--- a/src/main/java/com/profittracker/ProfitTrackerConfig.java
+++ b/src/main/java/com/profittracker/ProfitTrackerConfig.java
@@ -40,6 +40,17 @@ public interface ProfitTrackerConfig extends Config
     }
 
     @ConfigItem(
+            keyName = "unhideGoldDrops",
+            name = "Unhide value changes",
+            description = "Prevents other plugins from hiding value changes if they are enabled.",
+            section = visualSettings
+    )
+    default boolean unhideGoldDrops()
+    {
+        return true;
+    }
+
+    @ConfigItem(
             keyName = "autoStart",
             name = "Automatically start tracking",
             description = "Automatically begin tracking profit on session start.",

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -11,6 +11,7 @@ import net.runelite.api.gameval.InterfaceID;
 import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.VarbitID;
+import net.runelite.api.widgets.Widget;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ItemManager;
@@ -633,10 +634,16 @@ public class ProfitTrackerPlugin extends Plugin
         return configManager.getConfig(ProfitTrackerConfig.class);
     }
 
-
     @Subscribe
     public void onScriptPreFired(ScriptPreFired scriptPreFired)
     {
         goldDropsObject.onScriptPreFired(scriptPreFired);
+
+    }
+
+    @Subscribe
+    public void onScriptPostFired(ScriptPostFired event)
+    {
+        goldDropsObject.onScriptPostFired(event);
     }
 }


### PR DESCRIPTION
Added a config option which is only relevant when other plugins end up hiding our xp drops. If enabled, we unhide them.

This is an issue specifically when using the "[Customize XP Drops](https://github.com/l2-/template-plugin/tree/master)" plugin. As that plugin normally hides all xp drops so it can display its own custom versions of them. However, that plugin pulls data from the fake xp drop we create, before we have a chance to overwrite the sprite and text to what we actually want shown. Which results in a fake fishing xp drop by that plugin.

This should resolve #27. Though it would be better if that other plugin could instead read our sprite and text modifications to use in its custom display. Until then, this setting functions as a workaround that causes both to happen.

Opened an [issue](https://github.com/l2-/template-plugin/issues/150) on that repo. If it ends up getting fixed over there, we could probably remove this setting.