### PR TITLE
Fix GE modify button desync

### DIFF
--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -350,6 +350,12 @@ public class ProfitTrackerPlugin extends Plugin
                 break;
         }
         if (isStorage) {
+            if (closingWidgetId == event.getGroupId()) {
+                // GE can close and open immediately when using the modify button, which would otherwise cause temporary
+                // profit desync that is stuck until another offer changes. Resetting prevents accidentally thinking storage
+                // is closed the first tick it opens after having just closed.
+                closingWidgetId = 0;
+            }
             // If a user is flipping through multiple storages tick after tick, and moving items in/out
             // tracking can get complicated.
             // So we reset immediately to avoid longer term desyncs, like jumping between GE and bank


### PR DESCRIPTION
This fixes an issue with using the new modify button in the GE interface.

The button makes the GE widget to close and open immediately, which causes a tick of the plugin thinking the interface isn't actually open. This then caused profit change to occur when money gets taken to pay for the offer, and would only correct itself the next time an offer change happened.