### PR TITLE
Fix crash data loss, launch errors, and add some new config options

### DIFF
--- a/src/main/java/com/profittracker/ProfitTrackerConfig.java
+++ b/src/main/java/com/profittracker/ProfitTrackerConfig.java
@@ -75,6 +75,17 @@ public interface ProfitTrackerConfig extends Config
     }
 
     @ConfigItem(
+            keyName = "resetOnToggle",
+            name = "Reset on plugin toggle",
+            description = "Profit will be reset when the plugin is toggled on/off while logged in.",
+            section = BEHAVIOR_SETTINGS
+    )
+    default boolean resetOnToggle()
+    {
+        return true;
+    }
+
+    @ConfigItem(
             keyName = "shortDrops",
             name = "Shorten drop numbers",
             description = "Shorten drop numbers like 1.2K instead of 1,223, or 10M instead of 10,000,000.",

--- a/src/main/java/com/profittracker/ProfitTrackerConfig.java
+++ b/src/main/java/com/profittracker/ProfitTrackerConfig.java
@@ -180,5 +180,17 @@ public interface ProfitTrackerConfig extends Config
     {
         return Color.RED;
     }
+
+    @ConfigItem(
+            keyName = "showOverlay",
+            name = "Show overlay",
+            description = "Shows an overlay with information about the recorded data, like time, profit, or rate.",
+            section = VISUAL_SETTINGS,
+            position = 7
+    )
+    default boolean showOverlay()
+    {
+        return true;
+    }
 }
 

--- a/src/main/java/com/profittracker/ProfitTrackerOverlay.java
+++ b/src/main/java/com/profittracker/ProfitTrackerOverlay.java
@@ -31,6 +31,7 @@ public class ProfitTrackerOverlay extends Overlay {
     private String lastTimeDisplay;
     private long lastProfitValue;
     private int lastWidth;
+    private String errorString = "Error";
 
     private final ProfitTrackerConfig ptConfig;
     private final ProfitTrackerPlugin ptPlugin;
@@ -130,7 +131,7 @@ public class ProfitTrackerOverlay extends Overlay {
             // not in session
             // this should not happen if in game, but we can have it just in case
             panelComponent.getChildren().add(TitleComponent.builder()
-                    .text("Error")
+                    .text(errorString)
                     .color(Color.RED)
                     .build());
         }
@@ -222,6 +223,16 @@ public class ProfitTrackerOverlay extends Overlay {
                 {
                     inProfitTrackSession = true;
                     lastWidth = 0;
+                    errorString = "Error";
+                }
+        );
+    }
+
+    public void setErrorMessage(String newMessage)
+    {
+        SwingUtilities.invokeLater(() ->
+                {
+                    errorString = newMessage;
                 }
         );
     }

--- a/src/main/java/com/profittracker/ProfitTrackerOverlay.java
+++ b/src/main/java/com/profittracker/ProfitTrackerOverlay.java
@@ -120,6 +120,10 @@ public class ProfitTrackerOverlay extends Overlay {
         // Not sure how this can occur, but it was recommended to do so
         panelComponent.getChildren().clear();
 
+        if (!ptConfig.showOverlay()){
+            return null;
+        }
+
         // Build overlay title
         panelComponent.getChildren().add(TitleComponent.builder()
                 .text(titleText)

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -17,6 +17,7 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ClientShutdown;
 import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.events.ProfileChanged;
 import net.runelite.client.events.RuneScapeProfileChanged;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.chatbox.ChatboxPanelManager;
@@ -52,7 +53,6 @@ public class ProfitTrackerPlugin extends Plugin
     private long startTickMillis;
     private long activeTicks;
 
-    private boolean skipTickForProfitCalculation;
     private boolean inventoryValueChanged;
     private boolean bankValueChanged;
     private boolean grandExchangeValueChanged;
@@ -137,9 +137,6 @@ public class ProfitTrackerPlugin extends Plugin
         startTickMillis = 0;
         activeTicks = 0;
 
-        // skip profit calculation for first tick, to initialize first inventory value
-        skipTickForProfitCalculation = true;
-
         inventoryValueChanged = false;
 
         bankValueChanged = false;
@@ -196,6 +193,7 @@ public class ProfitTrackerPlugin extends Plugin
     {
         String accountIdentifier = ProfitTrackerRecord.getAccountRecordKey(client);
         if (accountIdentifier == null) {
+            overlay.setErrorMessage("Account ID Null");
             return;
         }
         boolean changedAccounts = previousAccount != null && ! previousAccount.contentEquals(accountIdentifier);
@@ -235,9 +233,11 @@ public class ProfitTrackerPlugin extends Plugin
     }
 
     @Subscribe
-    public void onRuneScapeProfileChanged(RuneScapeProfileChanged e)
-    {
-        checkAccount();
+    public void onGameStateChanged(GameStateChanged event) {
+        GameState state = event.getGameState();
+        if (state == GameState.LOGGED_IN) {
+            checkAccount();
+        }
     }
 
     @Override
@@ -430,11 +430,16 @@ public class ProfitTrackerPlugin extends Plugin
         if (grandExchangeValueChanged) {
             newPossessions.grandExchangeItems = inventoryValueObject.getGrandExchangeContents();
         }
-        accountRecord.currentPossessions.fillNullItems(newPossessions);
+        if (accountRecord.currentPossessions.fillNullItems(newPossessions)) {
+            // Gaining substantial new information, like opening the bank for the first time,
+            // learning inventory items, or equipped items. Save this to file to ensure the start point doesn't shift
+            // after a runelite crash.
+            accountRecord.save(gson);
+        }
         newPossessions.fillNullItems(accountRecord.currentPossessions);
         Item[] newItems = newPossessions.getItems();
 
-        if (!skipTickForProfitCalculation && accountRecord.currentPossessions.inventoryItems != null && newItems != null)
+        if (accountRecord.currentPossessions.inventoryItems != null && newItems != null)
         {
             // calculate new profit
             possessionDifference = inventoryValueObject.getItemCollectionDifference(accountRecord.currentPossessions.getItems(), newItems, config.estimateUntradeables());
@@ -446,8 +451,6 @@ public class ProfitTrackerPlugin extends Plugin
         {
             /* first time calculation / banking / equipping */
             log.debug("Skipping profit calculation!");
-
-            skipTickForProfitCalculation = false;
         }
 
         Item[] rawPossessionDifference = new Item[0];
@@ -627,7 +630,6 @@ public class ProfitTrackerPlugin extends Plugin
                     case "empty":
                     case "fill":
                     case "use":
-                        skipTickForProfitCalculation = false;
                 }
         }
 
@@ -664,8 +666,6 @@ public class ProfitTrackerPlugin extends Plugin
                     case "empty":
                     case "fill":
                     case "use":
-                        // Ensure item containers
-                        skipTickForProfitCalculation = false;
                 }
         }
 
@@ -712,8 +712,6 @@ public class ProfitTrackerPlugin extends Plugin
                     case "empty":
                     case "fill":
                     case "use":
-                        // Ensure item containers
-                        skipTickForProfitCalculation = false;
                 }
         }
     }
@@ -739,7 +737,9 @@ public class ProfitTrackerPlugin extends Plugin
     @Subscribe
     public void onClientShutdown(ClientShutdown event)
     {
-        accountRecord.save(gson);
+        if (accountRecord != null) {
+            accountRecord.save(gson);
+        }
     }
 
     @Subscribe

--- a/src/main/java/com/profittracker/ProfitTrackerPlugin.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPlugin.java
@@ -124,6 +124,13 @@ public class ProfitTrackerPlugin extends Plugin
         inventoryValueObject = new ProfitTrackerInventoryValue(client, itemManager, config);
 
         initializeVariables();
+
+        checkAccount();
+        if (config.resetOnToggle() && client.getGameState() == GameState.LOGGED_IN) {
+            // This causes a reset of the tracker when the plugin is toggled while logged-in
+            // While it can be reset via shift + right click, this is useful legacy behavior, and likely more intuitive
+            activeTicks = 0;
+        }
     }
 
     private void initializeVariables()

--- a/src/main/java/com/profittracker/ProfitTrackerPossessions.java
+++ b/src/main/java/com/profittracker/ProfitTrackerPossessions.java
@@ -25,19 +25,26 @@ public class ProfitTrackerPossessions {
 
     /**
      * If any collection is null, it will instead use the items from the given possessions
+     * Returns true if any null collection was given data
      */
-    public void fillNullItems(ProfitTrackerPossessions knownPossessions){
+    public boolean fillNullItems(ProfitTrackerPossessions knownPossessions){
+        boolean filled = false;
         if (inventoryItems == null){
             inventoryItems = knownPossessions.inventoryItems;
+            filled |= inventoryItems != null;
         }
         if (bankItems == null){
             bankItems = knownPossessions.bankItems;
+            filled |= bankItems != null;
         }
         if (grandExchangeItems == null){
             grandExchangeItems = knownPossessions.grandExchangeItems;
+            filled |= grandExchangeItems != null;
         }
         if (untrackedStorageItems == null){
             untrackedStorageItems = knownPossessions.untrackedStorageItems;
+            filled |= untrackedStorageItems != null;
         }
+        return filled;
     }
 }


### PR DESCRIPTION
* Added additional error message for null account ID failure (more troubleshooting for users running into error msg)
* Added config option to modify plugin toggle reset behavior
* Added config item to allow the overlay to be hidden (for people who just want the gold drops)

* Fixed #39 where runelite crashing causes a loss of profit info (time will become inaccurate, but at least you keep item data)
* Fixed launching the plugin while logged in, without any prior data, causing the plugin to not load properly

It is possible the last item addresses #40. Not sure on #37 as I couldn't reproduce any file related issues, though it may still have some effect there as well.